### PR TITLE
Set PACK_USER_ID:PACK_GROUP_ID on all files exported

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -128,7 +128,7 @@ func testPack(t *testing.T, when spec.G, it spec.S) {
 				launchPort := fetchHostPort(t, containerName)
 
 				time.Sleep(5 * time.Second)
-				assertEq(t, fetch(t, "http://localhost:"+launchPort), "Buildpacks Worked!")
+				assertEq(t, fetch(t, "http://localhost:"+launchPort), "Buildpacks Worked! - 1000:1000")
 
 				t.Log("Checking that registry is empty")
 				contents := fetch(t, fmt.Sprintf("http://localhost:%s/v2/_catalog", registryPort))
@@ -202,7 +202,7 @@ func testPack(t *testing.T, when spec.G, it spec.S) {
 				launchPort := fetchHostPort(t, containerName)
 
 				time.Sleep(5 * time.Second)
-				assertEq(t, fetch(t, "http://localhost:"+launchPort), "Buildpacks Worked!")
+				assertEq(t, fetch(t, "http://localhost:"+launchPort), "Buildpacks Worked! - 1000:1000")
 
 				t.Log("uses the cache on subsequent run")
 				output = runPackBuild()

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -240,26 +240,32 @@ func testPack(t *testing.T, when spec.G, it spec.S) {
 			sourceCodePath := filepath.Join("testdata", "mock_app")
 
 			t.Log("create builder image")
-			run(t, exec.Command(
+			cmd := exec.Command(
 				pack, "create-builder",
 				builderRepoName, "-b",
 				builderTOML, "--no-pull",
-			))
+			)
+			cmd.Env = append(os.Environ(), "HOME="+homeDir)
+			run(t, cmd)
 
 			t.Log("build uses order defined in builder.toml")
-			buildOutput := run(t, exec.Command(
+			cmd = exec.Command(
 				pack, "build", repoName,
 				"--builder", builderRepoName,
 				"--no-pull",
 				"--path", sourceCodePath,
-			))
+			)
+			cmd.Env = append(os.Environ(), "HOME="+homeDir)
+			buildOutput := run(t, cmd)
 			expectedDetectOutput := "First Mock Buildpack: pass | Second Mock Buildpack: pass | Third Mock Buildpack: pass"
 			if !strings.Contains(buildOutput, expectedDetectOutput) {
 				t.Fatalf(`Expected build output to contain detection output "%s", got "%s"`, expectedDetectOutput, buildOutput)
 			}
 
 			t.Log("run app container")
-			runOutput := run(t, exec.Command("docker", "run", "--name="+containerName, "--rm=true", repoName))
+			cmd = exec.Command("docker", "run", "--name="+containerName, "--rm=true", repoName)
+			cmd.Env = append(os.Environ(), "HOME="+homeDir)
+			runOutput := run(t, cmd)
 			if !strings.Contains(runOutput, "First Dep Contents") {
 				t.Fatalf(`Expected output to contain "First Dep Contents", got "%s"`, runOutput)
 			}
@@ -271,14 +277,16 @@ func testPack(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			t.Log("build with multiple --buildpack flags")
-			buildOutput = run(t, exec.Command(
+			cmd = exec.Command(
 				pack, "build", repoName,
 				"--builder", builderRepoName,
 				"--no-pull",
 				"--buildpack", "mock.bp.first",
 				"--buildpack", "mock.bp.third@0.0.3-mock",
 				"--path", sourceCodePath,
-			))
+			)
+			cmd.Env = append(os.Environ(), "HOME="+homeDir)
+			buildOutput = run(t, cmd)
 			latestInfo := `No version for 'mock.bp.first' buildpack provided, will use 'mock.bp.first@latest'`
 			if !strings.Contains(buildOutput, latestInfo) {
 				t.Fatalf(`expected build output to contain "%s", got "%s"`, latestInfo, buildOutput)
@@ -289,7 +297,9 @@ func testPack(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			t.Log("run app container")
-			runOutput = run(t, exec.Command("docker", "run", "--name="+containerName, "--rm=true", repoName))
+			cmd = exec.Command("docker", "run", "--name="+containerName, "--rm=true", repoName)
+			cmd.Env = append(os.Environ(), "HOME="+homeDir)
+			runOutput = run(t, cmd)
 			if !strings.Contains(runOutput, "Latest First Dep Contents") {
 				t.Fatalf(`Expected output to contain "First Dep Contents", got "%s"`, runOutput)
 			}

--- a/acceptance/testdata/node_app/app.js
+++ b/acceptance/testdata/node_app/app.js
@@ -1,11 +1,24 @@
+var fs = require('fs');
 var express = require('express');
 var app = express();
 const PORT = process.env.PORT || 3000;
 
 app.get('/', function (req, res) {
-  res.send('Buildpacks Worked!');
+    fs.stat('./', function(err, stat) {
+        if (err) {
+            res.send('Failed to stat ./');
+            return
+        }
+        fs.writeFile('./test-permission.txt', 'This file is used to test for write permission.', 'utf8', function (err) {
+            if (err) {
+                res.send('Failed to write ./test-permission.txt!');
+                return
+            }
+            res.send(`Buildpacks Worked! - ${stat.uid}:${stat.gid}`);
+        });
+    });
 });
 
 app.listen(PORT, function () {
-  console.log(`Example app listening on port ${PORT}!`);
+    console.log(`Example app listening on port ${PORT}!`);
 });

--- a/build.go
+++ b/build.go
@@ -412,7 +412,12 @@ func (b *BuildConfig) Export(group *lifecycle.BuildpackGroup) error {
 			buildpacks = append(buildpacks, b.ID)
 		}
 
-		if err := exportDaemon(b.Cli, buildpacks, b.WorkspaceVolume, b.RepoName, b.RunImage, b.Stdout); err != nil {
+		uid, gid, err := b.packUidGid(b.RunImage)
+		if err != nil {
+			return errors.Wrap(err, "export")
+		}
+
+		if err := exportDaemon(b.Cli, buildpacks, b.WorkspaceVolume, b.RepoName, b.RunImage, b.Stdout, uid, gid); err != nil {
 			return err
 		}
 	}
@@ -456,25 +461,30 @@ func (b *BuildConfig) packUidGid(builder string) (int, int, error) {
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "reading builder env variables")
 	}
-	var found, uid, gid int
+	var sUID, sGID string
 	for _, kv := range i.Config.Env {
 		kv2 := strings.SplitN(kv, "=", 2)
 		if len(kv2) == 2 && kv2[0] == "PACK_USER_ID" {
-			uid, err = strconv.Atoi(kv2[1])
-			if err != nil {
-				return 0, 0, errors.Wrapf(err, "parsing pack uid: %s", kv2[1])
-			}
-			found++
+			sUID = kv2[1]
+		} else if len(kv2) == 2 && kv2[0] == "PACK_GROUP_ID" {
+			sGID = kv2[1]
 		} else if len(kv2) == 2 && kv2[0] == "PACK_USER_GID" {
-			gid, err = strconv.Atoi(kv2[1])
-			if err != nil {
-				return 0, 0, errors.Wrapf(err, "parsing pack gid: %s", kv2[1])
+			if sGID == "" {
+				sGID = kv2[1]
 			}
-			found++
 		}
 	}
-	if found < 2 {
-		return uid, gid, errors.New("not found pack uid & gid")
+	if sUID == "" || sGID == "" {
+		return 0, 0, errors.New("not found pack uid & gid")
+	}
+	var uid, gid int
+	uid, err = strconv.Atoi(sUID)
+	if err != nil {
+		return 0, 0, errors.Wrapf(err, "parsing pack uid: %s", sUID)
+	}
+	gid, err = strconv.Atoi(sGID)
+	if err != nil {
+		return 0, 0, errors.Wrapf(err, "parsing pack gid: %s", sGID)
 	}
 	return uid, gid, nil
 }

--- a/build_test.go
+++ b/build_test.go
@@ -517,14 +517,14 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					assertContains(t, metadata.Buildpacks[0].Layers["other"].SHA, "sha256:")
 				})
 
-				it("sets owner of layer files to PACK_USER_ID:PACK_USER_GID", func() {
+				it("sets owner of layer files to PACK_USER_ID:PACK_GROUP_ID", func() {
 					subject.RunImage = "packs/run-" + randString(8)
 					defer exec.Command("docker", "rmi", subject.RunImage)
 					cmd := exec.Command("docker", "build", "-t", subject.RunImage, "-")
 					cmd.Stdin = strings.NewReader(`
 						FROM packs/run
 						ENV PACK_USER_ID 1234
-						ENV PACK_USER_GID 5678
+						ENV PACK_GROUP_ID 5678
 					`)
 					assertNil(t, cmd.Run())
 
@@ -541,20 +541,37 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					cmd.Stdin = strings.NewReader(`
 						FROM packs/run
 						ENV PACK_USER_ID ''
-						ENV PACK_USER_GID 5678
+						ENV PACK_GROUP_ID 5678
 					`)
 					assertNil(t, cmd.Run())
 
 					err := subject.Export(group)
-					assertError(t, err, "export uid/gid: could not find PACK_USER_ID && PACK_USER_GID from run image")
+					assertError(t, err, "export: not found pack uid & gid")
+				})
+
+				it("falls back to PACK_USER_GID sets owner of layer files", func() {
+					subject.RunImage = "packs/run-" + randString(8)
+					defer exec.Command("docker", "rmi", subject.RunImage)
+					cmd := exec.Command("docker", "build", "-t", subject.RunImage, "-")
+					cmd.Stdin = strings.NewReader(`
+						FROM packs/run
+						ENV PACK_USER_ID 1234
+						ENV PACK_USER_GID 5678
+					`)
+					assertNil(t, cmd.Run())
+
+					assertNil(t, subject.Export(group))
+					txt, err := exec.Command("docker", "run", subject.RepoName, "ls", "-la", "/workspace/app/file.txt").Output()
+					assertNil(t, err)
+					assertContains(t, string(txt), " 1234 5678 ")
 				})
 			})
 		})
 
 		when("previous image exists", func() {
 			it("reuses images from previous layers", func() {
-				addLayer := "ADD --chown=pack:pack /workspace/io.buildpacks.samples.nodejs/mylayer /workspace/io.buildpacks.samples.nodejs/mylayer"
-				copyLayer := "COPY --from=prev --chown=pack:pack /workspace/io.buildpacks.samples.nodejs/mylayer /workspace/io.buildpacks.samples.nodejs/mylayer"
+				addLayer := "ADD --chown=1000:1000 /workspace/io.buildpacks.samples.nodejs/mylayer /workspace/io.buildpacks.samples.nodejs/mylayer"
+				copyLayer := "COPY --from=prev --chown=1000:1000 /workspace/io.buildpacks.samples.nodejs/mylayer /workspace/io.buildpacks.samples.nodejs/mylayer"
 
 				t.Log("create image and assert add new layer")
 				assertNil(t, subject.Export(group))

--- a/exporter.go
+++ b/exporter.go
@@ -23,7 +23,7 @@ import (
 	"github.com/buildpack/packs"
 )
 
-func exportRegistry(group *lifecycle.BuildpackGroup, workspaceDir, repoName, stackName string, stdout, stderr io.Writer) (string, error) {
+func exportRegistry(group *lifecycle.BuildpackGroup, uid, gid int, workspaceDir, repoName, stackName string, stdout, stderr io.Writer) (string, error) {
 	images := &image.Client{}
 	origImage, err := images.ReadImage(repoName, false)
 	if err != nil {
@@ -51,6 +51,8 @@ func exportRegistry(group *lifecycle.BuildpackGroup, workspaceDir, repoName, sta
 		TmpDir:     tmpDir,
 		Out:        stdout,
 		Err:        stderr,
+		UID:        uid,
+		GID:        gid,
 	}
 	newImage, err := exporter.Export(
 		workspaceDir,

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/buildpack/pack
 
 require (
 	github.com/BurntSushi/toml v0.3.0
-	github.com/buildpack/lifecycle v0.0.0-20181011114133-95ef09f241cc
+	github.com/buildpack/lifecycle v0.0.0-20181011114133-50cfd4a07e58afc6b903611b5963f9825fd68af0
 	github.com/buildpack/packs v0.0.0-20180824001031-aa30a412923763df37e83f14a6e4e0fe07e11f25
 	github.com/docker/docker v0.7.3-0.20180531152204-71cd53e4a197
 	github.com/docker/go-connections v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/Microsoft/go-winio v0.4.9/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyv
 github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6nK2Q=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/aws/aws-sdk-go v1.15.2/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
-github.com/buildpack/lifecycle v0.0.0-20181011114133-95ef09f241cc h1:WdPXFkg1RI9Pvtev+DU4SyLSWZ0Rb2DzZv9ihXruARc=
-github.com/buildpack/lifecycle v0.0.0-20181011114133-95ef09f241cc/go.mod h1:rmQIWPE7ORJsSn/gHoT5fQAbsK7zV0X9yttd0cuGv5M=
+github.com/buildpack/lifecycle v0.0.0-20181011114133-50cfd4a07e58afc6b903611b5963f9825fd68af0 h1:XtnaP3JhxGFf7jeGheMozHsXY2d19+XPL2SSGO5q568=
+github.com/buildpack/lifecycle v0.0.0-20181011114133-50cfd4a07e58afc6b903611b5963f9825fd68af0/go.mod h1:rmQIWPE7ORJsSn/gHoT5fQAbsK7zV0X9yttd0cuGv5M=
 github.com/buildpack/packs v0.0.0-20180824001031-aa30a412923763df37e83f14a6e4e0fe07e11f25 h1:gaFgBRK9mKLhfH26GLqMYmriWawmcUvYYgta73tHVJ4=
 github.com/buildpack/packs v0.0.0-20180824001031-aa30a412923763df37e83f14a6e4e0fe07e11f25/go.mod h1:jcquCT5a2gbyJw8WMkfgq36g7yc5VDSABVnCctIUKs8=
 github.com/cpuguy83/go-md2man v1.0.8/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dYQLjr7cDsKY=


### PR DESCRIPTION
Pack cli had started using the user's UID&GID due for the registry export due to limitiations when copying  workspace to the local machine.

Also, changes PACK_USER_GID to PACK_GROUP_ID

NOTE: Should not be merged until after https://github.com/buildpack/lifecycle/pull/27 is merged