### PR TITLE
Use escaped id when creating buildpack tar file

### DIFF
--- a/build/lifecycle.go
+++ b/build/lifecycle.go
@@ -215,9 +215,9 @@ func createBuildpacksTars(tmpDir string, buildpacks []string, logger *logging.Lo
 			id = buildpackTOML.Buildpack.ID
 			version = buildpackTOML.Buildpack.Version
 
-			tarFile := filepath.Join(tmpDir, fmt.Sprintf("%s.%s.tar", id, version))
+			tarFile := filepath.Join(tmpDir, fmt.Sprintf("%s.%s.tar", buildpackTOML.Buildpack.EscapedID(), version))
 
-			if err := archive.CreateTar(tarFile, bp, filepath.Join("/buildpacks", id, version), uid, gid); err != nil {
+			if err := archive.CreateTar(tarFile, bp, filepath.Join("/buildpacks", buildpackTOML.Buildpack.EscapedID(), version), uid, gid); err != nil {
 				return nil, err
 			}
 

--- a/build/lifecycle_test.go
+++ b/build/lifecycle_test.go
@@ -200,7 +200,7 @@ func testLifecycle(t *testing.T, when spec.G, it spec.S) {
 						Logger:       logger,
 						Buildpacks: []string{
 							filepath.Join("testdata", "fake_buildpack"),
-							"just.buildpack.id@1.2.3",
+							"just/buildpack.id@1.2.3",
 						},
 						EnvFile: map[string]string{
 							"some-key":  "some-val",
@@ -237,7 +237,7 @@ func testLifecycle(t *testing.T, when spec.G, it spec.S) {
 				h.AssertContains(t, strings.Replace(outBuf.String(), "[phase]", "", -1),
 					`
    [[groups.buildpacks]]
-     id = "just.buildpack.id"
+     id = "just/buildpack.id"
      version = "1.2.3"
 `)
 			})


### PR DESCRIPTION
This fixes the case when the buildpack ID contains a `/`, which is allowed.

I'm also unsure if using the raw `version` string is acceptable. We should probably hash the whole buildpack name/id/version since this is never user facing.