### PR TITLE
Add group option to cache and restore step in lifecycle

### DIFF
--- a/build.go
+++ b/build.go
@@ -364,7 +364,7 @@ func (b *BuildConfig) detect(ctx context.Context, lifecycle *build.Lifecycle) er
 func (b *BuildConfig) restore(ctx context.Context, lifecycle *build.Lifecycle) error {
 	phase, err := lifecycle.NewPhase(
 		"restorer",
-		build.WithArgs("-image="+b.Cache.Image()),
+		build.WithArgs("-image="+b.Cache.Image(), "-group", groupPath),
 		build.WithDaemonAccess(),
 	)
 

--- a/build.go
+++ b/build.go
@@ -501,7 +501,7 @@ func (b *BuildConfig) export(ctx context.Context, lifecycle *build.Lifecycle) er
 func (b *BuildConfig) cache(ctx context.Context, lifecycle *build.Lifecycle) error {
 	phase, err := lifecycle.NewPhase(
 		"cacher",
-		build.WithArgs("-image="+b.Cache.Image()),
+		build.WithArgs("-image="+b.Cache.Image(), "-group", groupPath),
 		build.WithDaemonAccess(),
 	)
 


### PR DESCRIPTION
This was causing the following error on a fresh build:

```
$ pack build ...
...
===> RESTORING
[restorer] 2019/03/22 15:02:54 Error: failed to read group: open ./group.toml: no such file or directory
ERROR: run restorer container: failed with status code: 1
```