### PR TITLE
Return an error if the Stack.BuildImage is empty.

### DIFF
--- a/builder_factory.go
+++ b/builder_factory.go
@@ -70,6 +70,10 @@ func (f *BuilderFactory) BuilderConfigFromFlags(flags CreateBuilderFlags) (Build
 	}
 
 	baseImage := builderTOML.Stack.BuildImage
+	if baseImage == "" {
+		return BuilderConfig{}, fmt.Errorf("failed to decode builder config from file: missing stack.build-image")
+	}
+
 	builderConfig.RunImage = builderTOML.Stack.RunImage
 	builderConfig.RunImageMirrors = builderTOML.Stack.RunImageMirrors
 	if flags.Publish {

--- a/builder_factory_test.go
+++ b/builder_factory_test.go
@@ -364,6 +364,25 @@ run-image = "some/run"
 				}
 			})
 		})
+
+		it("fails when a stack.build-image is not provided", func() {
+			f, err := ioutil.TempFile("", "*.toml")
+			h.AssertNil(t, err)
+			ioutil.WriteFile(f.Name(), []byte(`
+[stack]
+id = "com.example.stack"
+run-image = "some/run"
+`), 0644)
+			flags := pack.CreateBuilderFlags{
+				RepoName:        "myorg/mybuilder",
+				BuilderTomlPath: f.Name(),
+				Publish:         false,
+				NoPull:          true,
+			}
+
+			_, err = factory.BuilderConfigFromFlags(flags)
+			h.AssertNotNil(t, err)
+		})
 	})
 }
 


### PR DESCRIPTION
Previously, the user would get the following error:
```
ERROR: opening base image: : could not parse reference
```

This error does not guide the developer towards the proper fix.