### PR TITLE
Allow rebase to use run image mirrors

### DIFF
--- a/build.go
+++ b/build.go
@@ -53,12 +53,11 @@ type BuildFlags struct {
 }
 
 type BuildConfig struct {
-	Builder                   string
-	RunImage                  string
-	RepoName                  string
-	Publish                   bool
-	ClearCache                bool
-	LocallyConfiguredRunImage bool
+	Builder    string
+	RunImage   string
+	RepoName   string
+	Publish    bool
+	ClearCache bool
 	// Above are copied from BuildFlags are set by init
 	Cli    Docker
 	Logger *logging.Logger
@@ -187,9 +186,8 @@ func (bf *BuildFactory) BuildConfigFromFlags(ctx context.Context, f *BuildFlags)
 	if f.RunImage != "" {
 		bf.Logger.Verbose("Using user-provided run image %s", style.Symbol(f.RunImage))
 		b.RunImage = f.RunImage
-		b.LocallyConfiguredRunImage = true
 	} else {
-		b.RunImage, b.LocallyConfiguredRunImage, err = builderImage.GetRunImageByRepoName(f.RepoName)
+		b.RunImage, err = builderImage.GetRunImageByRepoName(f.RepoName)
 		if err != nil {
 			return nil, err
 		}
@@ -426,10 +424,6 @@ type exporterArgs struct {
 	repoName string
 }
 
-func (e *exporterArgs) label(s string) {
-	e.args = append(e.args, "-label", s)
-}
-
 func (e *exporterArgs) add(args ...string) {
 	e.args = append(e.args, args...)
 }
@@ -444,18 +438,17 @@ func (e *exporterArgs) list() []string {
 }
 
 func (b *BuildConfig) export(ctx context.Context, lifecycle *build.Lifecycle) error {
-	var export *build.Phase
-	var err error
+	var (
+		export *build.Phase
+		err    error
+	)
 
 	args := &exporterArgs{repoName: b.RepoName}
-
-	args.add("-image", b.RunImage,
+	args.add(
+		"-image", b.RunImage,
 		"-layers", launchDir,
-		"-group", groupPath)
-
-	if !b.LocallyConfiguredRunImage {
-		args.label("io.buildpacks.run-image=" + b.RunImage)
-	}
+		"-group", groupPath,
+	)
 
 	if b.Publish {
 		export, err = lifecycle.NewPhase(
@@ -465,7 +458,6 @@ func (b *BuildConfig) export(ctx context.Context, lifecycle *build.Lifecycle) er
 		)
 	} else {
 		args.daemon()
-
 		export, err = lifecycle.NewPhase(
 			"exporter",
 			build.WithDaemonAccess(),
@@ -473,17 +465,17 @@ func (b *BuildConfig) export(ctx context.Context, lifecycle *build.Lifecycle) er
 		)
 	}
 	defer export.Cleanup()
+
 	uid, gid, err := b.packUidGid(ctx, b.Builder)
 	if err != nil {
 		return errors.Wrap(err, "get pack uid and gid")
 	}
+
 	if err := b.chownDir(ctx, lifecycle, launchDir, uid, gid); err != nil {
 		return errors.Wrap(err, "chown launch dir")
 	}
-	if err = export.Run(ctx); err != nil {
-		return err
-	}
-	return nil
+
+	return export.Run(ctx)
 }
 
 func (b *BuildConfig) cache(ctx context.Context, lifecycle *build.Lifecycle) error {

--- a/build_test.go
+++ b/build_test.go
@@ -67,7 +67,7 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 
 		it("defaults to daemon, default-builder, pulls builder and run images, selects run-image from builder", func() {
 			mockBuilderImage := mocks.NewMockImage(mockController)
-			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"runImage": {"image": "some/run"}}`, nil).AnyTimes()
+			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"stack":{"runImage": {"image": "some/run"}}}`, nil).AnyTimes()
 			mockFetcher.EXPECT().FetchUpdatedLocalImage(gomock.Any(), "some/builder", gomock.Any()).Return(mockBuilderImage, nil)
 
 			mockRunImage := mocks.NewMockImage(mockController)
@@ -80,13 +80,12 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 			})
 			h.AssertNil(t, err)
 			h.AssertEq(t, config.RunImage, "some/run")
-			h.AssertEq(t, config.LocallyConfiguredRunImage, false)
 			h.AssertEq(t, config.Builder, "some/builder")
 		})
 
 		it("respects builder from flags", func() {
 			mockBuilderImage := mocks.NewMockImage(mockController)
-			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"runImage": {"image": "some/run"}}`, nil).AnyTimes()
+			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"stack":{"runImage": {"image": "some/run"}}}`, nil).AnyTimes()
 			mockFetcher.EXPECT().FetchUpdatedLocalImage(gomock.Any(), "custom/builder", gomock.Any()).Return(mockBuilderImage, nil)
 
 			mockRunImage := mocks.NewMockImage(mockController)
@@ -99,13 +98,12 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 			})
 			h.AssertNil(t, err)
 			h.AssertEq(t, config.RunImage, "some/run")
-			h.AssertEq(t, config.LocallyConfiguredRunImage, false)
 			h.AssertEq(t, config.Builder, "custom/builder")
 		})
 
 		it("doesn't pull builder or run images when --no-pull is passed", func() {
 			mockBuilderImage := mocks.NewMockImage(mockController)
-			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"runImage": {"image": "some/run"}}`, nil).AnyTimes()
+			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"stack":{"runImage": {"image": "some/run"}}}`, nil).AnyTimes()
 			mockFetcher.EXPECT().FetchLocalImage("custom/builder").Return(mockBuilderImage, nil)
 
 			mockRunImage := mocks.NewMockImage(mockController)
@@ -119,14 +117,13 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 			})
 			h.AssertNil(t, err)
 			h.AssertEq(t, config.RunImage, "some/run")
-			h.AssertEq(t, config.LocallyConfiguredRunImage, false)
 			h.AssertEq(t, config.Builder, "custom/builder")
 		})
 
 		it("selects run images with matching registry", func() {
 			mockBuilderImage := mocks.NewMockImage(mockController)
 			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").
-				Return(`{"runImage": {"image": "some/run", "mirrors": ["registry.com/some/run"]}}`, nil).AnyTimes()
+				Return(`{"stack":{"runImage": {"image": "some/run", "mirrors": ["registry.com/some/run"]}}}`, nil).AnyTimes()
 			mockFetcher.EXPECT().FetchUpdatedLocalImage(gomock.Any(), "some/builder", gomock.Any()).Return(mockBuilderImage, nil)
 
 			mockRunImage := mocks.NewMockImage(mockController)
@@ -139,7 +136,6 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 			})
 			h.AssertNil(t, err)
 			h.AssertEq(t, config.RunImage, "registry.com/some/run")
-			h.AssertEq(t, config.LocallyConfiguredRunImage, false)
 			h.AssertEq(t, config.Builder, "some/builder")
 		})
 
@@ -156,7 +152,7 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 
 				mockBuilderImage := mocks.NewMockImage(mockController)
 				mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").
-					Return(`{"runImage": {"image": "default/run", "mirrors": ["registry.com/default/run"]}}`, nil).AnyTimes()
+					Return(`{"stack":{"runImage": {"image": "default/run", "mirrors": ["registry.com/default/run"]}}}`, nil).AnyTimes()
 				mockFetcher.EXPECT().FetchUpdatedLocalImage(gomock.Any(), "some/builder", gomock.Any()).Return(mockBuilderImage, nil)
 
 				mockRunImage = mocks.NewMockImage(mockController)
@@ -172,7 +168,6 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 				})
 				h.AssertNil(t, err)
 				h.AssertEq(t, config.RunImage, "registry.com/override/run")
-				h.AssertEq(t, config.LocallyConfiguredRunImage, true)
 				h.AssertEq(t, config.Builder, "some/builder")
 			})
 
@@ -185,14 +180,13 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 				})
 				h.AssertNil(t, err)
 				h.AssertEq(t, config.RunImage, "registry.com/override/run")
-				h.AssertEq(t, config.LocallyConfiguredRunImage, true)
 				h.AssertEq(t, config.Builder, "some/builder")
 			})
 		})
 
 		it("uses a remote run image when --publish is passed", func() {
 			mockBuilderImage := mocks.NewMockImage(mockController)
-			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"runImage": {"image": "some/run"}}`, nil).AnyTimes()
+			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"stack":{"runImage": {"image": "some/run"}}}`, nil).AnyTimes()
 			mockFetcher.EXPECT().FetchUpdatedLocalImage(gomock.Any(), "some/builder", gomock.Any()).Return(mockBuilderImage, nil)
 
 			mockRunImage := mocks.NewMockImage(mockController)
@@ -206,7 +200,6 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 			})
 			h.AssertNil(t, err)
 			h.AssertEq(t, config.RunImage, "some/run")
-			h.AssertEq(t, config.LocallyConfiguredRunImage, false)
 			h.AssertEq(t, config.Builder, "some/builder")
 		})
 
@@ -226,13 +219,12 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 			})
 			h.AssertNil(t, err)
 			h.AssertEq(t, config.RunImage, "override/run")
-			h.AssertEq(t, config.LocallyConfiguredRunImage, true)
 			h.AssertEq(t, config.Builder, "some/builder")
 		})
 
 		it("uses working dir if appDir is set to placeholder value", func() {
 			mockBuilderImage := mocks.NewMockImage(mockController)
-			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"runImage": {"image": "some/run"}}`, nil).AnyTimes()
+			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"stack":{"runImage": {"image": "some/run"}}}`, nil).AnyTimes()
 			mockFetcher.EXPECT().FetchUpdatedLocalImage(gomock.Any(), "some/builder", gomock.Any()).Return(mockBuilderImage, nil)
 
 			mockRunImage := mocks.NewMockImage(mockController)
@@ -247,7 +239,6 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 			})
 			h.AssertNil(t, err)
 			h.AssertEq(t, config.RunImage, "some/run")
-			h.AssertEq(t, config.LocallyConfiguredRunImage, false)
 			h.AssertEq(t, config.Builder, "some/builder")
 			h.AssertEq(t, config.LifecycleConfig.AppDir, os.Getenv("PWD"))
 		})
@@ -314,7 +305,7 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 
 		it("sets Env", func() {
 			mockBuilderImage := mocks.NewMockImage(mockController)
-			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"runImage": {"image": "some/run"}}`, nil).AnyTimes()
+			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"stack":{"runImage": {"image": "some/run"}}}`, nil).AnyTimes()
 			mockFetcher.EXPECT().FetchUpdatedLocalImage(gomock.Any(), "some/builder", gomock.Any()).Return(mockBuilderImage, nil)
 
 			mockRunImage := mocks.NewMockImage(mockController)
@@ -341,7 +332,7 @@ func testBuildFactory(t *testing.T, when spec.G, it spec.S) {
 
 		it("sets EnvFile", func() {
 			mockBuilderImage := mocks.NewMockImage(mockController)
-			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"runImage": {"image": "some/run"}}`, nil).AnyTimes()
+			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"stack":{"runImage": {"image": "some/run"}}}`, nil).AnyTimes()
 			mockFetcher.EXPECT().FetchUpdatedLocalImage(gomock.Any(), "some/builder", gomock.Any()).Return(mockBuilderImage, nil)
 
 			mockRunImage := mocks.NewMockImage(mockController)
@@ -376,7 +367,7 @@ PATH
 
 		it("sets EnvFile with Env overrides", func() {
 			mockBuilderImage := mocks.NewMockImage(mockController)
-			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"runImage": {"image": "some/run"}}`, nil).AnyTimes()
+			mockBuilderImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{"stack":{"runImage": {"image": "some/run"}}}`, nil).AnyTimes()
 			mockFetcher.EXPECT().FetchUpdatedLocalImage(gomock.Any(), "some/builder", gomock.Any()).Return(mockBuilderImage, nil)
 
 			mockRunImage := mocks.NewMockImage(mockController)

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -60,45 +60,40 @@ func (b *Builder) GetLocalRunImageMirrors() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if runImage := b.config.GetRunImage(metadata.RunImage.Image); runImage != nil {
+	if runImage := b.config.GetRunImage(metadata.Stack.RunImage.Image); runImage != nil {
 		return runImage.Mirrors, nil
 	}
 	return []string{}, nil
 }
 
-func (b *Builder) GetRunImageByRepoName(repoName string) (runImage string, locallyConfigured bool, err error) {
+func (b *Builder) GetRunImageByRepoName(repoName string) (runImage string, err error) {
 	desiredRegistry, err := registry(repoName)
 	if err != nil {
-		return "", false, err
+		return "", err
 	}
 
 	metadata, err := b.GetMetadata()
 	if err != nil {
-		return "", false, err
+		return "", err
 	}
 
 	localRunImageMirrors, err := b.GetLocalRunImageMirrors()
 	if err != nil {
-		return "", false, err
+		return "", err
 	}
 
-	for _, img := range localRunImageMirrors {
+	runImageList := append(localRunImageMirrors, append([]string{metadata.Stack.RunImage.Image}, metadata.Stack.RunImage.Mirrors...)...)
+	for _, img := range runImageList {
 		if reg, err := registry(img); err == nil && reg == desiredRegistry {
-			return img, true, nil
-		}
-	}
-
-	for _, img := range append([]string{metadata.RunImage.Image}, metadata.RunImage.Mirrors...) {
-		if reg, err := registry(img); err == nil && reg == desiredRegistry {
-			return img, false, nil
+			return img, nil
 		}
 	}
 
 	if len(localRunImageMirrors) > 0 {
-		return localRunImageMirrors[0], true, nil
+		return localRunImageMirrors[0], nil
 	}
 
-	return metadata.RunImage.Image, false, nil
+	return metadata.Stack.RunImage.Image, nil
 }
 
 func registry(imageName string) (string, error) {

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -98,12 +98,8 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 	when("#GetLocalRunImageMirrors", func() {
 		when("run image exists in config", func() {
 			it.Before(func() {
-				mockImage.EXPECT().Label("io.buildpacks.builder.metadata").Return(`{
- "runImage": {
-   "image": "some/run-image",
-   "mirrors": []
- }
-}`, nil)
+				mockImage.EXPECT().Label("io.buildpacks.builder.metadata").
+					Return(`{"stack":{"runImage": {"image": "some/run-image","mirrors": []}}}`, nil)
 				cfg.RunImages = []config.RunImage{{Image: "some/run-image", Mirrors: []string{"a", "b"}}}
 			})
 
@@ -137,16 +133,11 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 	when("#GetRunImageByRepoName", func() {
 		when("there are NOT local run image mirrors", func() {
 			it("should return the remote run image for the repo", func() {
-				mockImage.EXPECT().Label(builder.MetadataLabel).Return(`{
- "runImage": {
-   "image": "some/run-image",
-   "mirrors": ["foo.bar/other/run-image", "gcr.io/extra/run-image"]
- }
-}`, nil).AnyTimes()
+				mockImage.EXPECT().Label(builder.MetadataLabel).
+					Return(`{"stack":{"runImage": {"image": "some/run-image","mirrors": ["foo.bar/other/run-image", "gcr.io/extra/run-image"]}}}`, nil).AnyTimes()
 
-				runImage, isLocal, err := subject.GetRunImageByRepoName("gcr.io/foo/bar")
+				runImage, err := subject.GetRunImageByRepoName("gcr.io/foo/bar")
 				h.AssertNil(t, err)
-				h.AssertEq(t, isLocal, false)
 				h.AssertEq(t, runImage, "gcr.io/extra/run-image")
 			})
 		})
@@ -154,28 +145,22 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 		when("there are local run image mirrors", func() {
 			it.Before(func() {
 				cfg.RunImages = []config.RunImage{{Image: "some/run-image", Mirrors: []string{"gcr.io/another/run-image", "foo.bar/ignored"}}}
-				mockImage.EXPECT().Label(builder.MetadataLabel).Return(`{
- "runImage": {
-   "image": "some/run-image",
-   "mirrors": ["foo.bar/other/run-image", "gcr.io/extra/run-image"]
- }
-}`, nil).AnyTimes()
+				mockImage.EXPECT().Label(builder.MetadataLabel).
+					Return(`{"stack":{"runImage": {"image": "some/run-image","mirrors": ["foo.bar/other/run-image", "gcr.io/extra/run-image"]}}}`, nil).AnyTimes()
 			})
 
 			when("one matches the given repo", func() {
 				it("should return the local run image for the repo", func() {
-					runImage, isLocal, err := subject.GetRunImageByRepoName("gcr.io/foo/bar")
+					runImage, err := subject.GetRunImageByRepoName("gcr.io/foo/bar")
 					h.AssertNil(t, err)
-					h.AssertEq(t, isLocal, true)
 					h.AssertEq(t, runImage, "gcr.io/another/run-image")
 				})
 			})
 
 			when("none match the given repo", func() {
 				it("should return the non-local run image for the repo", func() {
-					runImage, isLocal, err := subject.GetRunImageByRepoName("some/run-image")
+					runImage, err := subject.GetRunImageByRepoName("some/run-image")
 					h.AssertNil(t, err)
-					h.AssertEq(t, isLocal, false)
 					h.AssertEq(t, runImage, "some/run-image")
 				})
 			})
@@ -183,7 +168,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 
 		when("the repo name is invalid", func() {
 			it("should err", func() {
-				_, _, err := subject.GetRunImageByRepoName("!!@@##$$%%")
+				_, err := subject.GetRunImageByRepoName("!!@@##$$%%")
 				h.AssertNotNil(t, err)
 			})
 		})

--- a/builder/metadata.go
+++ b/builder/metadata.go
@@ -2,7 +2,9 @@ package builder
 
 import (
 	"github.com/buildpack/lifecycle"
+
 	"github.com/buildpack/pack/buildpack"
+	"github.com/buildpack/pack/stack"
 )
 
 const MetadataLabel = "io.buildpacks.builder.metadata"
@@ -21,14 +23,9 @@ type Stack struct {
 }
 
 type Metadata struct {
-	RunImage   RunImageMetadata    `json:"runImage"`
 	Buildpacks []BuildpackMetadata `json:"buildpacks"`
 	Groups     []GroupMetadata     `json:"groups"`
-}
-
-type RunImageMetadata struct {
-	Image   string   `json:"image"`
-	Mirrors []string `json:"mirrors"`
+	Stack      stack.Metadata      `json:"stack"`
 }
 
 type BuildpackMetadata struct {

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -98,6 +99,10 @@ func (c *Config) SetRunImageMirrors(image string, mirrors []string) {
 }
 
 func ImageByRegistry(registry string, images []string) (string, error) {
+	if len(images) < 1 {
+		return "", errors.New("no images provided to search")
+	}
+
 	for _, i := range images {
 		reg, err := Registry(i)
 		if err != nil {

--- a/create_builder_test.go
+++ b/create_builder_test.go
@@ -409,12 +409,14 @@ run-image = "some/run"
 				mockImage     *mocks.MockImage
 				savedLayers   map[string]*bytes.Buffer
 				labels        map[string]string
+				env           map[string]string
 				builderConfig pack.BuilderConfig
 			)
 
 			it.Before(func() {
 				savedLayers = make(map[string]*bytes.Buffer)
 				labels = make(map[string]string)
+				env = make(map[string]string)
 
 				mockImage = mocks.NewMockImage(mockController)
 				mockImage.EXPECT().AddLayer(gomock.Any()).Do(func(layerPath string) {
@@ -427,10 +429,11 @@ run-image = "some/run"
 
 					savedLayers[filepath.Base(layerPath)] = bytes.NewBuffer(buf)
 				}).AnyTimes()
-				mockImage.EXPECT().Save()
 				mockImage.EXPECT().SetLabel(gomock.Any(), gomock.Any()).Do(func(labelName, labelValue string) {
 					labels[labelName] = labelValue
 				})
+				mockImage.EXPECT().SetEnv(gomock.Any(), gomock.Any()).Do(func(key, val string) { env[key] = val }).AnyTimes()
+				mockImage.EXPECT().Save()
 
 				builderConfig = pack.BuilderConfig{
 					Repo:            mockImage,
@@ -446,8 +449,25 @@ run-image = "some/run"
 				h.AssertNil(t, factory.Create(builderConfig))
 				h.AssertEq(t,
 					labels["io.buildpacks.builder.metadata"],
-					`{"runImage":{"image":"myorg/run","mirrors":["gcr.io/myorg/run"]},"buildpacks":[],"groups":[]}`,
+					`{"buildpacks":[],"groups":[],"stack":{"runImage":{"image":"myorg/run","mirrors":["gcr.io/myorg/run"]}}}`,
 				)
+			})
+
+			it("writes a stack.toml file", func() {
+				h.AssertNil(t, factory.Create(builderConfig))
+
+				content, exists := savedLayers["stack.tar"]
+				h.AssertEq(t, exists, true)
+				h.AssertContains(t, content.String(), `[run-image]`)
+				h.AssertContains(t, content.String(), `image = "myorg/run"`)
+				h.AssertContains(t, content.String(), `mirrors = ["gcr.io/myorg/run"]`)
+			})
+
+			it("writes the stack.toml file path to an env var", func() {
+				h.AssertNil(t, factory.Create(builderConfig))
+				content, exists := env["CNB_STACK_PATH"]
+				h.AssertEq(t, exists, true)
+				h.AssertContains(t, content, "/buildpacks/stack.toml")
 			})
 
 			when("builder config contains buildpacks", func() {
@@ -461,7 +481,7 @@ run-image = "some/run"
 					h.AssertNil(t, factory.Create(builderConfig))
 					h.AssertEq(t,
 						labels["io.buildpacks.builder.metadata"],
-						`{"runImage":{"image":"myorg/run","mirrors":["gcr.io/myorg/run"]},"buildpacks":[{"id":"some-buildpack-id","version":"some-buildpack-version","latest":true}],"groups":[]}`,
+						`{"buildpacks":[{"id":"some-buildpack-id","version":"some-buildpack-version","latest":true}],"groups":[],"stack":{"runImage":{"image":"myorg/run","mirrors":["gcr.io/myorg/run"]}}}`,
 					)
 				})
 			})
@@ -485,7 +505,7 @@ run-image = "some/run"
 					h.AssertNil(t, factory.Create(builderConfig))
 					h.AssertEq(t,
 						labels["io.buildpacks.builder.metadata"],
-						`{"runImage":{"image":"myorg/run","mirrors":["gcr.io/myorg/run"]},"buildpacks":[],"groups":[{"buildpacks":[{"id":"bpId","version":"bpVersion","latest":false}]}]}`,
+						`{"buildpacks":[],"groups":[{"buildpacks":[{"id":"bpId","version":"bpVersion","latest":false}]}],"stack":{"runImage":{"image":"myorg/run","mirrors":["gcr.io/myorg/run"]}}}`,
 					)
 				})
 			})

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/buildpack/pack
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.12 // indirect
-	github.com/buildpack/lifecycle v0.0.0-20190314183328-a6ea5e18de72
+	github.com/buildpack/lifecycle v0.0.0-20190327221653-eecd1c5c1b4c
 	github.com/dgodd/dockerdial v1.0.1
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.7.3-0.20190307005417-54dddadc7d5d

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEV
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/buildpack/lifecycle v0.0.0-20190314183328-a6ea5e18de72 h1:tCYd4NvBTgrb+7VP8vgZmOO4ecK9i/RKAArO2EAJ20I=
 github.com/buildpack/lifecycle v0.0.0-20190314183328-a6ea5e18de72/go.mod h1:35fR8AHcmIc9UHt/XE0Js3UzA260lNqQMhgH4HQ3vPM=
+github.com/buildpack/lifecycle v0.0.0-20190327221653-eecd1c5c1b4c h1:jiEogU54RaQCF9/ZqwHbrrcFJmMFdOu5VQdO3FpLAvE=
+github.com/buildpack/lifecycle v0.0.0-20190327221653-eecd1c5c1b4c/go.mod h1:35fR8AHcmIc9UHt/XE0Js3UzA260lNqQMhgH4HQ3vPM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/inspect_builder.go
+++ b/inspect_builder.go
@@ -44,9 +44,9 @@ func (c *Client) InspectBuilder(name string, daemon bool) (*BuilderInfo, error) 
 
 	bldr := builder.NewBuilder(img, c.config)
 
-	stack, err := bldr.GetStack()
+	stackID, err := bldr.GetStack()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get stack for builder image '%s'", name)
+		return nil, errors.Wrapf(err, "failed to get stackID for builder image '%s'", name)
 	}
 
 	metadata, err := bldr.GetMetadata()
@@ -72,9 +72,9 @@ func (c *Client) InspectBuilder(name string, daemon bool) (*BuilderInfo, error) 
 	}
 
 	return &BuilderInfo{
-		Stack:                stack,
-		RunImage:             metadata.RunImage.Image,
-		RunImageMirrors:      metadata.RunImage.Mirrors,
+		Stack:                stackID,
+		RunImage:             metadata.Stack.RunImage.Image,
+		RunImageMirrors:      metadata.Stack.RunImage.Mirrors,
 		LocalRunImageMirrors: localMirrors,
 		Buildpacks:           buildpacks,
 		Groups:               groups,

--- a/inspect_builder_test.go
+++ b/inspect_builder_test.go
@@ -62,11 +62,13 @@ func testInspectBuilder(t *testing.T, when spec.G, it spec.S) {
 					it.Before(func() {
 						testhelpers.AssertNil(t, builderImage.SetLabel("io.buildpacks.stack.id", "test.stack.id"))
 						testhelpers.AssertNil(t, builderImage.SetLabel("io.buildpacks.builder.metadata", `{
-  "runImage": {
-    "image": "some/run-image",
-    "mirrors": [
-      "gcr.io/some/default"
-    ]
+  "stack": {
+    "runImage": {
+      "image": "some/run-image",
+      "mirrors": [
+        "gcr.io/some/default"
+      ]
+    }
   },
   "buildpacks": [
     {

--- a/stack/metadata.go
+++ b/stack/metadata.go
@@ -1,0 +1,10 @@
+package stack
+
+type Metadata struct {
+	RunImage RunImageMetadata `toml:"run-image" json:"runImage"`
+}
+
+type RunImageMetadata struct {
+	Image   string   `toml:"image" json:"image"`
+	Mirrors []string `toml:"mirrors" json:"mirrors"`
+}

--- a/testhelpers/registry.go
+++ b/testhelpers/registry.go
@@ -217,8 +217,11 @@ func DefaultBuilderImage(t *testing.T, registryPort string) string {
 
 		CreateImageOnLocal(t, dockerCli, newName, fmt.Sprintf(`
 					FROM %s
-					LABEL %s="{\"runImage\": {\"image\": \"%s\"}}"
-				`, origName, builder.MetadataLabel, runImageName))
+					LABEL %s="{\"stack\":{\"runImage\": {\"image\": \"%s\"}}}"
+					USER root
+					RUN echo "[run-image]\n  image=\"%s\"" > /buildpacks/stack.toml
+					USER pack
+				`, origName, builder.MetadataLabel, runImageName, runImageName))
 	})
 	return newName
 }


### PR DESCRIPTION
* create-builder writes stack.toml with run image and mirrors metadata

[buildpack/roadmap#48]

Signed-off-by: Danny Joyce <djoyce@pivotal.io>
Signed-off-by: Andrew Meyer <ameyer@pivotal.io>
Signed-off-by: Emily Casey <ecasey@pivotal.io>

**Wait for https://github.com/buildpack/lifecycle/pull/100 to merge**