### PR TITLE
Fix build not failing when CreateTarReader returns an error

### DIFF
--- a/build/phase.go
+++ b/build/phase.go
@@ -118,9 +118,14 @@ func (p *Phase) Run(context context.Context) error {
 		return errors.Wrapf(err, "failed to create '%s' container", p.name)
 	}
 	p.appOnce.Do(func() {
-		appReader, _ := archive.CreateTarReader(p.appDir, appDir, p.uid, p.gid, runtime.GOOS == "windows")
+		appReader, errChan := archive.CreateTarReader(p.appDir, appDir, p.uid, p.gid, runtime.GOOS == "windows")
 		if err = p.docker.CopyToContainer(context, p.ctr.ID, "/", appReader, types.CopyToContainerOptions{}); err != nil {
 			err = errors.Wrapf(err, "failed to copy files to '%s' container", p.name)
+		}
+
+		err = <-errChan
+		if err != nil {
+			err = errors.Wrapf(err, "create tar archive from '%s'", p.appDir)
 		}
 	})
 	if err != nil {


### PR DESCRIPTION
I've been hunting a weird issue for a while where files were missing from my workspace.

Eventually I tracked it down to a `archive/tar: sockets not supported` error returned from `(tar.Writer* )WriteHeader(header)`. This is caused by the unix domain sockets that are often used by ruby servers.

That specific scenario is covered by the test added in the PR.
The code that fixes the problem is more broad than what is tested and also includes other types of files that will be filtered from the tar such as `fifo` named pipes, device files (for example if someone symlinked to `/dev/whatever`.

It would be a very good idea to implement some `.gitignore`-like mechanism, maybe in a `.packignore` file, but that's a story for another change. I'll work on that one in parallel cause it's very important to me (otherwise developer credentials may find themselves in the production build)