### PR TITLE
create-builder only validates remote run-images when publish is true

### DIFF
--- a/create_builder.go
+++ b/create_builder.go
@@ -121,17 +121,19 @@ func validateBuilderConfig(conf builder.Config) error {
 func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderOptions) error {
 	var runImages []imgutil.Image
 	for _, i := range append([]string{opts.BuilderConfig.Stack.RunImage}, opts.BuilderConfig.Stack.RunImageMirrors...) {
-		img, err := c.imageFetcher.Fetch(ctx, i, true, false)
-		if err != nil {
-			if errors.Cause(err) != image.ErrNotFound {
-				return err
+		if !opts.Publish {
+			img, err := c.imageFetcher.Fetch(ctx, i, true, false)
+			if err != nil {
+				if errors.Cause(err) != image.ErrNotFound {
+					return err
+				}
+			} else {
+				runImages = append(runImages, img)
+				continue
 			}
-		} else {
-			runImages = append(runImages, img)
-			continue
 		}
 
-		img, err = c.imageFetcher.Fetch(ctx, i, false, false)
+		img, err := c.imageFetcher.Fetch(ctx, i, false, false)
 		if err != nil {
 			if errors.Cause(err) != image.ErrNotFound {
 				return err

--- a/create_builder_test.go
+++ b/create_builder_test.go
@@ -204,6 +204,19 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertContains(t, out.String(), "Warning: run image 'some/run-image' is not accessible")
 			})
+
+			when("publish is true", func() {
+				it("should only try to validate the remote run image", func() {
+					delete(imageFetcher.LocalImages, "some/run-image")
+					delete(imageFetcher.LocalImages, "some/build-image")
+					imageFetcher.RemoteImages["some/run-image"] = fakeRunImage
+					imageFetcher.RemoteImages["some/build-image"] = fakeBuildImage
+
+					opts.Publish = true
+					err := subject.CreateBuilder(context.TODO(), opts)
+					h.AssertNil(t, err)
+				})
+			})
 		})
 
 		it("should create a new builder image", func() {


### PR DESCRIPTION
Signed-off-by: Emily Casey <ecasey@pivotal.io>