### PR TITLE
ignore unix domain socket files in archive.WriteDirToTar

### DIFF
--- a/build/lifecycle_test.go
+++ b/build/lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildpack/imgutil"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
@@ -19,7 +20,6 @@ import (
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
-	"github.com/buildpack/imgutil"
 	"github.com/buildpack/pack/build"
 	"github.com/buildpack/pack/builder"
 	"github.com/buildpack/pack/internal/archive"

--- a/build/testdata/bad-fake-app/fake-app-file
+++ b/build/testdata/bad-fake-app/fake-app-file
@@ -1,1 +1,0 @@
-fake-app-contents

--- a/build/testdata/bad-fake-app/fake-app-file
+++ b/build/testdata/bad-fake-app/fake-app-file
@@ -1,0 +1,1 @@
+fake-app-contents

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -144,6 +144,10 @@ func WriteDirToTar(tw *tar.Writer, srcDir, tarDir string, uid, gid int, mode int
 			return err
 		}
 
+		if !fi.Mode().IsRegular() && !fi.IsDir() {
+			return nil
+		}
+
 		var header *tar.Header
 		if fi.Mode()&os.ModeSymlink != 0 {
 			target, err := os.Readlink(file)

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -144,12 +144,14 @@ func WriteDirToTar(tw *tar.Writer, srcDir, tarDir string, uid, gid int, mode int
 			return err
 		}
 
-		if !fi.Mode().IsRegular() && !fi.IsDir() {
+		isSymlink := fi.Mode()&os.ModeSymlink != 0
+
+		if !fi.Mode().IsRegular() && !fi.IsDir() && !isSymlink {
 			return nil
 		}
 
 		var header *tar.Header
-		if fi.Mode()&os.ModeSymlink != 0 {
+		if isSymlink {
 			target, err := os.Readlink(file)
 			if err != nil {
 				return err

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -144,14 +144,12 @@ func WriteDirToTar(tw *tar.Writer, srcDir, tarDir string, uid, gid int, mode int
 			return err
 		}
 
-		isSymlink := fi.Mode()&os.ModeSymlink != 0
-
-		if !fi.Mode().IsRegular() && !fi.IsDir() && !isSymlink {
+		if fi.Mode()&os.ModeSocket != 0 {
 			return nil
 		}
 
 		var header *tar.Header
-		if isSymlink {
+		if fi.Mode()&os.ModeSymlink != 0 {
 			target, err := os.Readlink(file)
 			if err != nil {
 				return err


### PR DESCRIPTION
At the moment `archive.WriteDirToTar` will fail if there are any unix domain socket files in the directory tree being archived (the app).
This change skips those files assuming they should not be copied, [since they can't be](https://github.com/golang/go/blob/release-branch.go1.12/src/archive/tar/common.go#L658)