### PR TITLE
Handle context cancelling when executing container

### DIFF
--- a/build/testdata/fake-lifecycle/vendor/github.com/docker/docker/api/types/container/host_config.go
+++ b/build/testdata/fake-lifecycle/vendor/github.com/docker/docker/api/types/container/host_config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/go-connections/nat"
-	"github.com/docker/go-units"
+	units "github.com/docker/go-units"
 )
 
 // Isolation represents the isolation technology of a container. The supported

--- a/container/run_test.go
+++ b/container/run_test.go
@@ -1,0 +1,91 @@
+package container_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	dockertypes "github.com/docker/docker/api/types"
+	dcontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpack/imgutil"
+	"github.com/buildpack/pack/container"
+	"github.com/buildpack/pack/internal/archive"
+	h "github.com/buildpack/pack/testhelpers"
+)
+
+var (
+	repoName string
+	docker   *client.Client
+)
+
+func TestContainerRun(t *testing.T) {
+	h.RequireDocker(t)
+
+	var err error
+	docker, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+	h.AssertNil(t, err)
+
+	repoName = "lifecycle.test." + h.RandString(10)
+	CreateFakeLifecycleImage(t, docker, repoName)
+	defer h.DockerRmi(docker, repoName)
+
+	spec.Run(t, "ContainerRun", testContainerRun, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testContainerRun(t *testing.T, when spec.G, it spec.S) {
+	when("#Run", func() {
+		var (
+			outBuf, errBuf bytes.Buffer
+			ctr            dcontainer.ContainerCreateCreatedBody
+		)
+
+		it.Before(func() {
+			var err error
+
+			image, err := imgutil.NewLocalImage(repoName, docker)
+			h.AssertNil(t, err)
+
+			ctrConf := &dcontainer.Config{
+				Image:  image.Name(),
+				Labels: map[string]string{"author": "pack"},
+			}
+
+			hostConf := &dcontainer.HostConfig{}
+
+			ctr, err = docker.ContainerCreate(context.Background(), ctrConf, hostConf, nil, "")
+			h.AssertNil(t, err)
+		})
+
+		it("runs a container", func() {
+			err := container.Run(context.Background(), docker, ctr.ID, &outBuf, &errBuf)
+			h.AssertNil(t, err)
+			h.AssertContains(t, outBuf.String(), "Hello From Docker")
+		})
+	})
+}
+
+func CreateFakeLifecycleImage(t *testing.T, docker *client.Client, repoName string) {
+	ctx := context.Background()
+
+	wd, err := os.Getwd()
+	h.AssertNil(t, err)
+	buildContext, _ := archive.CreateTarReader(filepath.Join(wd, "testdata", "fake-run"), "/", 0, 0, -1)
+
+	res, err := docker.ImageBuild(ctx, buildContext, dockertypes.ImageBuildOptions{
+		Tags:        []string{repoName},
+		Remove:      true,
+		ForceRemove: true,
+	})
+	h.AssertNil(t, err)
+
+	io.Copy(ioutil.Discard, res.Body)
+	res.Body.Close()
+}

--- a/container/run_test.go
+++ b/container/run_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	dockertypes "github.com/docker/docker/api/types"
 	dcontainer "github.com/docker/docker/api/types/container"
@@ -16,14 +17,31 @@ import (
 	"github.com/sclevine/spec/report"
 
 	"github.com/buildpack/imgutil"
+
 	"github.com/buildpack/pack/container"
 	"github.com/buildpack/pack/internal/archive"
 	h "github.com/buildpack/pack/testhelpers"
 )
 
+var repos = map[string]struct {
+	repoName   string
+	testFolder string
+	ctrID      string
+}{
+	"default": {
+		repoName:   "lifecycle.test." + h.RandString(10),
+		testFolder: "fake-run",
+	},
+	"slow": {
+		repoName:   "lifecycle.test." + h.RandString(10),
+		testFolder: "slow-run",
+	},
+}
+
 var (
-	repoName string
-	docker   *client.Client
+	repoName     string
+	slowRepoName string
+	docker       *client.Client
 )
 
 func TestContainerRun(t *testing.T) {
@@ -33,9 +51,10 @@ func TestContainerRun(t *testing.T) {
 	docker, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
 	h.AssertNil(t, err)
 
-	repoName = "lifecycle.test." + h.RandString(10)
-	CreateFakeLifecycleImage(t, docker, repoName)
-	defer h.DockerRmi(docker, repoName)
+	for _, r := range repos {
+		CreateFakeImage(t, docker, r.testFolder, r.repoName)
+		defer h.DockerRmi(docker, r.repoName)
+	}
 
 	spec.Run(t, "ContainerRun", testContainerRun, spec.Parallel(), spec.Report(report.Terminal{}))
 }
@@ -44,40 +63,53 @@ func testContainerRun(t *testing.T, when spec.G, it spec.S) {
 	when("#Run", func() {
 		var (
 			outBuf, errBuf bytes.Buffer
-			ctr            dcontainer.ContainerCreateCreatedBody
 		)
 
 		it.Before(func() {
-			var err error
+			for k, r := range repos {
+				image, err := imgutil.NewLocalImage(r.repoName, docker)
+				h.AssertNil(t, err)
 
-			image, err := imgutil.NewLocalImage(repoName, docker)
-			h.AssertNil(t, err)
+				hostConf := &dcontainer.HostConfig{}
+				ctrConf := &dcontainer.Config{
+					Image:  image.Name(),
+					Labels: map[string]string{"author": "pack"},
+				}
 
-			ctrConf := &dcontainer.Config{
-				Image:  image.Name(),
-				Labels: map[string]string{"author": "pack"},
+				ctr, err := docker.ContainerCreate(context.Background(), ctrConf, hostConf, nil, "")
+				h.AssertNil(t, err)
+				r.ctrID = ctr.ID
+				repos[k] = r
 			}
-
-			hostConf := &dcontainer.HostConfig{}
-
-			ctr, err = docker.ContainerCreate(context.Background(), ctrConf, hostConf, nil, "")
-			h.AssertNil(t, err)
 		})
 
 		it("runs a container", func() {
-			err := container.Run(context.Background(), docker, ctr.ID, &outBuf, &errBuf)
+			err := container.Run(context.Background(), docker, repos["default"].ctrID, &outBuf, &errBuf)
 			h.AssertNil(t, err)
 			h.AssertContains(t, outBuf.String(), "Hello From Docker")
+		})
+
+		it("can cancel a running container", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				time.Sleep(2 * time.Second)
+				cancel()
+			}()
+
+			err := container.Run(ctx, docker, repos["slow"].ctrID, &outBuf, &errBuf)
+			h.AssertNil(t, err)
+			h.AssertContains(t, outBuf.String(), "Hello From Docker")
+			h.AssertNotContains(t, outBuf.String(), "Hello after sleeping")
 		})
 	})
 }
 
-func CreateFakeLifecycleImage(t *testing.T, docker *client.Client, repoName string) {
+func CreateFakeImage(t *testing.T, docker *client.Client, testRun, repoName string) {
 	ctx := context.Background()
 
 	wd, err := os.Getwd()
 	h.AssertNil(t, err)
-	buildContext, _ := archive.CreateTarReader(filepath.Join(wd, "testdata", "fake-run"), "/", 0, 0, -1)
+	buildContext, _ := archive.CreateTarReader(filepath.Join(wd, "testdata", testRun), "/", 0, 0, -1)
 
 	res, err := docker.ImageBuild(ctx, buildContext, dockertypes.ImageBuildOptions{
 		Tags:        []string{repoName},

--- a/container/testdata/fake-run/Dockerfile
+++ b/container/testdata/fake-run/Dockerfile
@@ -1,0 +1,2 @@
+FROM golang
+CMD echo "Hello From Docker"

--- a/container/testdata/slow-run/Dockerfile
+++ b/container/testdata/slow-run/Dockerfile
@@ -1,0 +1,2 @@
+FROM golang
+CMD echo "Hello From Docker"; sleep 10; echo "Hello after sleeping"


### PR DESCRIPTION
When cancelling a running build (for example with Ctrl-C in the CLI), we should be able to cancel any running container right away.
With this change, we will properly respect when the context is cancelled by killing the currently running container, and therefore stopping the build.