### PR TITLE
Skip layer analysis when clearing cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,6 @@ else
 		$(GOCMD) fmt ./...
 endif
 
-
-
 imports:
 	go install -mod=vendor golang.org/x/tools/cmd/goimports
 ifeq ($(PACK_CI), true)
@@ -31,10 +29,10 @@ vet:
 	$(GOCMD) vet -mod=vendor $$($(GOCMD) list ./... | grep -v /testdata/)
 
 test: unit acceptance
-	
+
 unit: format imports vet
 	$(GOCMD) test -mod=vendor -v -count=1 -parallel=1 -timeout=0 ./...
-	
+
 acceptance: format imports vet
 	$(GOCMD) test -mod=vendor -v -count=1 -parallel=1 -timeout=0 -tags=acceptance ./acceptance
 

--- a/build/phase_test.go
+++ b/build/phase_test.go
@@ -34,7 +34,7 @@ var (
 	dockerCli *client.Client
 )
 
-func TestLifecycle(t *testing.T) {
+func TestPhase(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	color.NoColor = true
@@ -49,10 +49,10 @@ func TestLifecycle(t *testing.T) {
 	CreateFakeLifecycleImage(t, dockerCli, repoName)
 	defer h.DockerRmi(dockerCli, repoName)
 
-	spec.Run(t, "lifecycle", testLifecycle, spec.Report(report.Terminal{}), spec.Parallel())
+	spec.Run(t, "lifecycle", testPhase, spec.Report(report.Terminal{}), spec.Parallel())
 }
 
-func testLifecycle(t *testing.T, when spec.G, it spec.S) {
+func testPhase(t *testing.T, when spec.G, it spec.S) {
 	var (
 		subject        *build.Lifecycle
 		outBuf, errBuf bytes.Buffer
@@ -130,7 +130,6 @@ func testLifecycle(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			when("is posix", func() {
-
 				it.Before(func() {
 					h.SkipIf(t, runtime.GOOS == "windows", "Skipping on windows")
 				})


### PR DESCRIPTION
Skip layer analysis for analyzer when clearing cache
- For older lifecycles, continue to skip analyze altogether

Relates to buildpack/lifecycle#138

Signed-off-by: Andrew Meyer <ameyer@pivotal.io>
Signed-off-by: Javier Romero <jromero@pivotal.io>