### PR TITLE
Stop the lifecycle if the context moved to done

### DIFF
--- a/build/lifecycle.go
+++ b/build/lifecycle.go
@@ -82,9 +82,17 @@ func (l *Lifecycle) Execute(ctx context.Context, opts LifecycleOptions) error {
 		l.logger.Debugf("Executing lifecycle version %s", style.Symbol(lifecycleVersion.String()))
 	}
 
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	l.logger.Debug(style.Step("DETECTING"))
 	if err := l.Detect(ctx); err != nil {
 		return err
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
 
 	l.logger.Debug(style.Step("RESTORING"))
@@ -92,6 +100,10 @@ func (l *Lifecycle) Execute(ctx context.Context, opts LifecycleOptions) error {
 		l.logger.Debug("Skipping 'restore' due to clearing cache")
 	} else if err := l.Restore(ctx, l.supportsVolumeCache(), buildCache.Name()); err != nil {
 		return err
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
 
 	l.logger.Debug(style.Step("ANALYZING"))
@@ -103,9 +115,17 @@ func (l *Lifecycle) Execute(ctx context.Context, opts LifecycleOptions) error {
 		}
 	}
 
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	l.logger.Debug(style.Step("BUILDING"))
 	if err := l.Build(ctx); err != nil {
 		return err
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
 
 	l.logger.Debug(style.Step("EXPORTING"))
@@ -115,6 +135,10 @@ func (l *Lifecycle) Execute(ctx context.Context, opts LifecycleOptions) error {
 	}
 	if err := l.Export(ctx, opts.Image.Name(), opts.RunImage, opts.Publish, launchCacheName); err != nil {
 		return err
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
 
 	l.logger.Debug(style.Step("CACHING"))


### PR DESCRIPTION
This goes in the same vein as #219, to allow cancelling a running build.
A context can move to done at any of those step, meaning we shouldn't execute the following ones.

`Execute()` has no tests at all, and it would be quite difficult to write a tests which cancel the context at a specific step. I'm happy to look into writing tests if a suggestion is provided though.