### PR TITLE
Makefile 'build' target should only build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SRC:=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 all: clean verify test build
 
-build: format vet
+build:
 	@echo "> Building..."
 	mkdir -p ./out
 	$(GOENV) $(GOCMD) build -mod=vendor -ldflags "-X 'main.Version=${PACK_VERSION}'" -o ./out/$(PACK_BIN) -a ./cmd/pack


### PR DESCRIPTION
Running `make build` should not be expected to modify the source by running `format` as a target dependency. 

Additionally, it currently has unintended consequences when attempting to build for an alternative OS. For example, running `GOOS=darwin make build` on a `linux` machine fails due to `goimports` being installed as the `darwin` variant.

Signed-off-by: Javier Romero <jromero@pivotal.io>