### PR TITLE
Fix issue where buildpack uris are treated like ids

### DIFF
--- a/build.go
+++ b/build.go
@@ -236,14 +236,13 @@ func isBuildpackId(path string) bool {
 		return false
 	}
 
-	hasScheme := schemeRegexp.MatchString(path)
-	if !hasScheme {
-		if _, err := os.Stat(path); err == nil {
-			return false
+	if !schemeRegexp.MatchString(path) {
+		if _, err := os.Stat(path); err != nil {
+			return true
 		}
 	}
 
-	return true
+	return false
 }
 
 func (c *Client) parseBuildpack(bp string) (string, string) {


### PR DESCRIPTION
Signed-off-by: Emily Casey <ecasey@pivotal.io>
Signed-off-by: Javier Romero <jromero@pivotal.io>