### PR TITLE
Provide warning when reading builder.toml

### DIFF
--- a/build.go
+++ b/build.go
@@ -256,7 +256,7 @@ func (c *Client) parseBuildpack(bp string) (string, string) {
 	parts := strings.Split(bp, "@")
 	if len(parts) == 2 {
 		if parts[1] == "latest" {
-			c.logger.Info(style.Tip("WARNING: ") + "@latest syntax is deprecated, will not work in future releases")
+			c.logger.Warn("@latest syntax is deprecated, will not work in future releases")
 			return parts[0], ""
 		}
 

--- a/build/lifecycle.go
+++ b/build/lifecycle.go
@@ -79,7 +79,7 @@ func (l *Lifecycle) Execute(ctx context.Context, opts LifecycleOptions) error {
 
 	lifecycleVersion := l.builder.GetLifecycleVersion()
 	if lifecycleVersion == nil {
-		l.logger.Debug("Warning: lifecycle version unknown")
+		l.logger.Warn("lifecycle version unknown")
 		lifecycleVersion = semver.MustParse(lifecycle.DefaultLifecycleVersion)
 	} else {
 		l.logger.Debugf("Executing lifecycle version %s", style.Symbol(lifecycleVersion.String()))

--- a/build_test.go
+++ b/build_test.go
@@ -544,7 +544,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 							}},
 						}},
 					})
-					h.AssertContains(t, outBuf.String(), "WARNING: @latest syntax is deprecated, will not work in future releases")
+					h.AssertContains(t, outBuf.String(), "Warning: @latest syntax is deprecated, will not work in future releases")
 				})
 			})
 

--- a/builder/config.go
+++ b/builder/config.go
@@ -1,10 +1,13 @@
 package builder
 
 import (
+	"fmt"
 	"io"
 	"net/url"
 	"os"
 	"path/filepath"
+
+	"github.com/buildpack/pack/style"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
@@ -38,32 +41,83 @@ type LifecycleConfig struct {
 	Version string `toml:"version"`
 }
 
-// ReadConfig reads a builder configuration from the file path provided
-func ReadConfig(path string) (Config, error) {
+// ReadConfig reads a builder configuration from the file path provided and returns the
+// configuration along with any warnings encountered while parsing
+func ReadConfig(path string) (config Config, warnings []string, err error) {
 	builderDir, err := filepath.Abs(filepath.Dir(path))
 	if err != nil {
-		return Config{}, err
+		return Config{}, nil, err
 	}
 
 	file, err := os.Open(path)
 	if err != nil {
-		return Config{}, errors.Wrap(err, "opening config file")
+		return Config{}, nil, errors.Wrap(err, "opening config file")
 	}
 	defer file.Close()
 
-	config, err := parseConfig(file, builderDir)
+	warnings, err = getWarnings(file)
 	if err != nil {
-		return Config{}, errors.Wrapf(err, "parse contents of '%s'", path)
+		return Config{}, nil, errors.Wrapf(err, "check warnings for file '%s'", path)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return Config{}, nil, errors.Wrap(err, "reset config file pointer")
 	}
 
-	return config, nil
+	config, err = parseConfig(file, builderDir)
+	if err != nil {
+		return Config{}, nil, errors.Wrapf(err, "parse contents of '%s'", path)
+	}
+
+	return config, warnings, nil
+}
+
+func getWarnings(reader io.Reader) ([]string, error) {
+	var warnings []string
+
+	var obsoleteConfig = struct {
+		Buildpacks []struct {
+			Latest bool
+		}
+		Groups []interface{}
+		Order  []struct {
+			Group []interface{}
+		}
+	}{}
+
+	if _, err := toml.DecodeReader(reader, &obsoleteConfig); err != nil {
+		return nil, err
+	}
+
+	latestUsed := false
+
+	for _, bp := range obsoleteConfig.Buildpacks {
+		latestUsed = bp.Latest
+	}
+
+	if latestUsed {
+		warnings = append(warnings, fmt.Sprintf("%s field on a buildpack is obsolete and will be ignored", style.Symbol("latest")))
+	}
+
+	if len(obsoleteConfig.Groups) > 0 {
+		warnings = append(warnings, fmt.Sprintf("%s field is obsolete in favor of %s", style.Symbol("groups"), style.Symbol("order")))
+	}
+
+	totalOrderItems := 0
+	for _, g := range obsoleteConfig.Order {
+		totalOrderItems += len(g.Group)
+	}
+	if totalOrderItems == 0 {
+		warnings = append(warnings, fmt.Sprintf("empty %s definition", style.Symbol("order")))
+	}
+
+	return warnings, nil
 }
 
 // parseConfig reads a builder configuration from reader and resolves relative buildpack paths using `relativeToDir`
-func parseConfig(reader io.Reader, relativeToDir string) (Config, error) {
-	builderConfig := Config{}
+func parseConfig(reader io.Reader, relativeToDir string) (config Config, err error) {
+	var builderConfig Config
 	if _, err := toml.DecodeReader(reader, &builderConfig); err != nil {
-		return builderConfig, errors.Wrap(err, "decoding toml contents")
+		return Config{}, errors.Wrap(err, "decoding toml contents")
 	}
 
 	for i, bp := range builderConfig.Buildpacks {

--- a/builder/config_test.go
+++ b/builder/config_test.go
@@ -92,7 +92,7 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 
 			})
 
-			when("'groups' field is used instead of 'order'", func() {
+			when("'groups' field is used", func() {
 				it.Before(func() {
 					h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
 [[buildpacks]]
@@ -103,6 +103,10 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 [[groups.buildpacks]]
   id = "some.buildpack"
   version = "some.buildpack.version"
+
+[[order]]
+[[order.group]]
+  id = "some.buildpack"
 `), 0666))
 				})
 
@@ -110,8 +114,25 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 					_, warns, err := builder.ReadConfig(builderConfigPath)
 					h.AssertNil(t, err)
 
-					h.AssertEq(t, len(warns), 2)
+					h.AssertEq(t, len(warns), 1)
 					h.AssertSliceContains(t, warns, "'groups' field is obsolete in favor of 'order'")
+				})
+			})
+
+			when("'order' is missing or empty", func() {
+				it.Before(func() {
+					h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
+[[buildpacks]]
+  id = "some.buildpack"
+  version = "some.buildpack.version"
+`), 0666))
+				})
+
+				it("returns warnings", func() {
+					_, warns, err := builder.ReadConfig(builderConfigPath)
+					h.AssertNil(t, err)
+
+					h.AssertEq(t, len(warns), 1)
 					h.AssertSliceContains(t, warns, "empty 'order' definition")
 				})
 			})

--- a/cmd/pack/main.go
+++ b/cmd/pack/main.go
@@ -34,13 +34,13 @@ func main() {
 		Use: "pack",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if fs := cmd.Flags(); fs != nil {
-				if flag, err := fs.GetBool("no-color"); err != nil {
+				if flag, err := fs.GetBool("no-color"); err == nil {
 					color.NoColor = flag
 				}
-				if flag, err := fs.GetBool("quiet"); err != nil {
+				if flag, err := fs.GetBool("quiet"); err == nil {
 					logger.WantQuiet(flag)
 				}
-				if flag, err := fs.GetBool("timestamps"); err != nil {
+				if flag, err := fs.GetBool("timestamps"); err == nil {
 					logger.WantTime(flag)
 				}
 			}

--- a/commands/create_builder.go
+++ b/commands/create_builder.go
@@ -26,10 +26,14 @@ func CreateBuilder(logger logging.Logger, client PackClient) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Short: "Create builder image",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			builderConfig, err := builder.ReadConfig(flags.BuilderTomlPath)
+			builderConfig, warns, err := builder.ReadConfig(flags.BuilderTomlPath)
 			if err != nil {
 				return errors.Wrap(err, "invalid builder toml")
 			}
+			for _, w := range warns {
+				logger.Warnf("builder configuration: %s", w)
+			}
+
 			imageName := args[0]
 			if err := client.CreateBuilder(ctx, pack.CreateBuilderOptions{
 				BuilderName:   imageName,

--- a/commands/create_builder_test.go
+++ b/commands/create_builder_test.go
@@ -1,0 +1,78 @@
+package commands_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/golang/mock/gomock"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpack/pack/commands"
+	cmdmocks "github.com/buildpack/pack/commands/mocks"
+	"github.com/buildpack/pack/internal/mocks"
+	"github.com/buildpack/pack/logging"
+	h "github.com/buildpack/pack/testhelpers"
+)
+
+func TestCreateBuilderCommand(t *testing.T) {
+	color.NoColor = true
+	spec.Run(t, "Commands", testCreateBuilderCommand, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		command           *cobra.Command
+		logger            logging.Logger
+		outBuf            bytes.Buffer
+		mockController    *gomock.Controller
+		mockClient        *cmdmocks.MockPackClient
+		tmpDir            string
+		builderConfigPath string
+	)
+
+	it.Before(func() {
+		var err error
+		tmpDir, err = ioutil.TempDir("", "create-builder-test")
+		h.AssertNil(t, err)
+		builderConfigPath = filepath.Join(tmpDir, "builder.toml")
+
+		mockController = gomock.NewController(t)
+		mockClient = cmdmocks.NewMockPackClient(mockController)
+		logger = mocks.NewMockLogger(&outBuf)
+		command = commands.CreateBuilder(logger, mockClient)
+	})
+
+	it.After(func() {
+		mockController.Finish()
+	})
+
+	when("#CreateBuilder", func() {
+		when("warnings encountered in builder.toml", func() {
+			it.Before(func() {
+				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
+[[buildpacks]]
+  id = "some.buildpack"
+  latest = true
+`), 0666))
+			})
+
+			it("logs the warnings", func() {
+				mockClient.EXPECT().CreateBuilder(gomock.Any(), gomock.Any()).Return(nil)
+
+				command.SetArgs([]string{
+					"some/builder",
+					"--builder-config", builderConfigPath,
+				})
+				h.AssertNil(t, command.Execute())
+
+				h.AssertContains(t, outBuf.String(), "Warning: builder configuration: 'latest' field on a buildpack is obsolete and will be ignored")
+				h.AssertContains(t, outBuf.String(), "Warning: builder configuration: empty 'order' definition")
+			})
+		})
+	})
+}

--- a/commands/inspect_builder.go
+++ b/commands/inspect_builder.go
@@ -84,7 +84,8 @@ func inspectBuilderOutput(logger logging.Logger, client PackClient, imageName st
 	logger.Info("")
 
 	if info.RunImage == "" {
-		logger.Infof("\nWarning: '%s' does not specify a run image", imageName)
+		logger.Info("")
+		logger.Warnf("%s does not specify a run image", style.Symbol(imageName))
 		logger.Info("  Users must build with an explicitly specified run image")
 	} else {
 		logger.Info("Run Images:")
@@ -99,14 +100,16 @@ func inspectBuilderOutput(logger logging.Logger, client PackClient, imageName st
 	}
 
 	if len(info.Buildpacks) == 0 {
-		logger.Infof("\nWarning: '%s' has no buildpacks", imageName)
+		logger.Info("")
+		logger.Warnf("%s has no buildpacks", style.Symbol(imageName))
 		logger.Info("  Users must supply buildpacks from the host machine")
 	} else {
 		logBuildpacksInfo(logger, info)
 	}
 
 	if len(info.Groups) == 0 {
-		logger.Infof("\nWarning: '%s' does not specify detection order", imageName)
+		logger.Info("")
+		logger.Warnf("%s does not specify detection order", style.Symbol(imageName))
 		logger.Info("  Users must build with explicitly specified buildpacks")
 	} else {
 		logDetectionOrderInfo(logger, info)

--- a/create_builder.go
+++ b/create_builder.go
@@ -143,7 +143,7 @@ func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderO
 			if errors.Cause(err) != image.ErrNotFound {
 				return err
 			}
-			c.logger.Infof("Warning: run image %s is not accessible", style.Symbol(i))
+			c.logger.Warnf("run image %s is not accessible", style.Symbol(i))
 		} else {
 			runImages = append(runImages, img)
 		}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -10,14 +10,14 @@ import (
 	"time"
 
 	"github.com/apex/log"
-	"github.com/fatih/color"
 
 	"github.com/buildpack/pack/style"
 )
 
-// Terminal colors
 const (
-	errorLevelText = "ERROR"
+	errorLevelText = "ERROR: "
+	warnLevelText  = "Warning: "
+
 	// time format the out logging uses
 	timeFmt = "2006/01/02 15:04:05.000000"
 )
@@ -31,12 +31,13 @@ type handler struct {
 }
 
 func formatLevel(ll log.Level) string {
-	if ll == log.ErrorLevel {
-		if color.NoColor {
-			return fmt.Sprintf("%-6s ", errorLevelText)
-		}
-		return style.Error("%-6s ", errorLevelText)
+	switch ll {
+	case log.ErrorLevel:
+		return style.Error(errorLevelText)
+	case log.WarnLevel:
+		return style.Warn(warnLevelText)
 	}
+
 	return ""
 }
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -51,20 +51,20 @@ func TestPackCLILogger(t *testing.T) {
 		it("can enable time in logs", func() {
 			logger.WantTime(true)
 			logger.Error("test")
-			expected := "2019/05/15 01:01:01.000000 \x1b[31;1mERROR  \x1b[0mtest                     \n"
+			expected := "2019/05/15 01:01:01.000000 \x1b[31;1mERROR: \x1b[0mtest                     \n"
 			h.AssertEq(t, log.String(), expected)
 		})
 
 		it("it has no time and color by default", func() {
 			logger.Error("test")
-			expected := "\x1b[31;1mERROR  \x1b[0mtest                     \n"
+			expected := "\x1b[31;1mERROR: \x1b[0mtest                     \n"
 			h.AssertEq(t, log.String(), expected)
 		})
 
 		it("can disable color logs", func() {
 			color.NoColor = true
 			logger.Error("test")
-			expected := "ERROR  test                     \n"
+			expected := "ERROR: test                     \n"
 			h.AssertEq(t, log.String(), expected)
 		})
 

--- a/internal/mocks/logger.go
+++ b/internal/mocks/logger.go
@@ -23,11 +23,15 @@ func NewMockLogger(w io.Writer) *mockLog {
 }
 
 func (ml *mockLog) HandleLog(e *log.Entry) error {
-	if e.Level == log.ErrorLevel {
+	switch e.Level {
+	case log.WarnLevel:
+		_, _ = fmt.Fprintf(ml.w, "Warning: %s\n", e.Message)
+	case log.ErrorLevel:
 		_, _ = fmt.Fprintf(ml.w, "ERROR: %s\n", e.Message)
-		return nil
+	default:
+		_, _ = fmt.Fprintln(ml.w, e.Message)
 	}
-	_, _ = fmt.Fprintln(ml.w, e.Message)
+
 	return nil
 }
 

--- a/logging/default_logger.go
+++ b/logging/default_logger.go
@@ -20,6 +20,7 @@ type defaultLogger struct {
 const (
 	debugPrefix = "DEBUG:"
 	infoPrefix  = "INFO:"
+	warnPrefix  = "WARN:"
 	errorPrefix = "ERROR:"
 	prefixFmt   = "%-7s %s"
 )
@@ -38,6 +39,14 @@ func (l *defaultLogger) Info(msg string) {
 
 func (l *defaultLogger) Infof(format string, v ...interface{}) {
 	l.out.Printf(prefixFmt, infoPrefix, fmt.Sprintf(format, v...))
+}
+
+func (l *defaultLogger) Warn(msg string) {
+	l.out.Printf(prefixFmt, warnPrefix, msg)
+}
+
+func (l *defaultLogger) Warnf(format string, v ...interface{}) {
+	l.out.Printf(prefixFmt, warnPrefix, fmt.Sprintf(format, v...))
 }
 
 func (l *defaultLogger) Error(msg string) {

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -12,10 +12,16 @@ import (
 type Logger interface {
 	Debug(msg string)
 	Debugf(fmt string, v ...interface{})
+
 	Info(msg string)
 	Infof(fmt string, v ...interface{})
+
+	Warn(msg string)
+	Warnf(fmt string, v ...interface{})
+
 	Error(msg string)
 	Errorf(fmt string, v ...interface{})
+
 	Writer() io.Writer
 }
 

--- a/style/style.go
+++ b/style/style.go
@@ -21,6 +21,8 @@ var Key = color.HiBlueString
 
 var Tip = color.New(color.FgGreen, color.Bold).SprintfFunc()
 
+var Warn = color.New(color.FgYellow, color.Bold).SprintfFunc()
+
 var Error = color.New(color.FgRed, color.Bold).SprintfFunc()
 
 var Step = func(format string, a ...interface{}) string {


### PR DESCRIPTION
Resolves #255 

* Provide warning when reading builder.toml
* Add `Warn` and `Warnf` methods to logger
* Fix: quiet, no-color, timestamps flags not respected