### PR TITLE
Fix pack completion command

### DIFF
--- a/commands/completion.go
+++ b/commands/completion.go
@@ -25,6 +25,10 @@ To configure your bash shell to load completions for each session, add the follo
 			if err != nil {
 				return errors.Wrap(err, "getting pack home")
 			}
+
+			if err = config.MkdirAll(packHome); err != nil {
+				return errors.Wrapf(err, "creating pack home: %s", packHome)
+			}
 			completionPath := filepath.Join(packHome, "completion")
 
 			if err := cmd.Parent().GenBashCompletionFile(completionPath); err != nil {

--- a/commands/completion_test.go
+++ b/commands/completion_test.go
@@ -1,0 +1,81 @@
+package commands_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpack/pack/commands"
+	"github.com/buildpack/pack/internal/mocks"
+	"github.com/buildpack/pack/logging"
+	h "github.com/buildpack/pack/testhelpers"
+)
+
+func TestCompletionCommand(t *testing.T) {
+	spec.Run(t, "Commands", testCompletionCommand, spec.Random(), spec.Report(report.Terminal{}))
+}
+
+func testCompletionCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		command    *cobra.Command
+		logger     logging.Logger
+		outBuf     bytes.Buffer
+		packHome   string
+		missingDir string
+	)
+
+	it.Before(func() {
+		logger = mocks.NewMockLogger(&outBuf)
+		// the CompletionCommand calls a method on its Parent(), so it needs to have
+		// one.
+		command = &cobra.Command{}
+		command.AddCommand(commands.CompletionCommand(logger))
+		command.SetArgs([]string{"completion"})
+		var err error
+		packHome, err = ioutil.TempDir("", "")
+		h.AssertNil(t, err)
+		missingDir = filepath.Join(packHome, "not-found")
+	})
+
+	it.After(func() {
+		os.RemoveAll(packHome)
+	})
+
+	when("#CompletionCommand", func() {
+		when("PackHome directory does exist", func() {
+			it.Before(func() {
+				os.Setenv("PACK_HOME", packHome)
+			})
+
+			it.After(func() {
+				os.Unsetenv("PACK_HOME")
+			})
+
+			it("creates the completion file", func() {
+				h.AssertNil(t, command.Execute())
+				h.AssertContains(t, outBuf.String(), filepath.Join(packHome, "completion"))
+			})
+		})
+
+		when("PackHome directory does not exist", func() {
+			it.Before(func() {
+				os.Setenv("PACK_HOME", missingDir)
+			})
+
+			it.After(func() {
+				os.Unsetenv("PACK_HOME")
+			})
+
+			it("creates the completion file", func() {
+				h.AssertNil(t, command.Execute())
+				h.AssertContains(t, outBuf.String(), filepath.Join(missingDir, "completion"))
+			})
+		})
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -49,7 +49,7 @@ func Read(path string) (Config, error) {
 }
 
 func Write(cfg Config, path string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+	if err := MkdirAll(filepath.Dir(path)); err != nil {
 		return err
 	}
 	w, err := os.Create(path)
@@ -59,6 +59,10 @@ func Write(cfg Config, path string) error {
 	defer w.Close()
 
 	return toml.NewEncoder(w).Encode(cfg)
+}
+
+func MkdirAll(path string) error {
+	return os.MkdirAll(path, 0777)
 }
 
 func SetRunImageMirrors(cfg Config, image string, mirrors []string) Config {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,6 +108,29 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#MkdirAll", func() {
+		when("the directory doesn't exist yet", func() {
+			it("creates the directory", func() {
+				path := filepath.Join(tmpDir, "a-new-dir")
+				err := config.MkdirAll(path)
+				h.AssertNil(t, err)
+				fi, err := os.Stat(path)
+				h.AssertNil(t, err)
+				h.AssertEq(t, fi.Mode().IsDir(), true)
+			})
+		})
+
+		when("the directory already exists", func() {
+			it("doesn't error", func() {
+				err := config.MkdirAll(tmpDir)
+				h.AssertNil(t, err)
+				fi, err := os.Stat(tmpDir)
+				h.AssertNil(t, err)
+				h.AssertEq(t, fi.Mode().IsDir(), true)
+			})
+		})
+	})
+
 	when("#SetRunImageMirrors", func() {
 		when("run image exists in config", func() {
 			it("replaces the mirrors", func() {


### PR DESCRIPTION
The `pack completion` command throws an error if the `PACK_HOME`
directory doesn't exist. (as described in #272)

This PR makes sure the directory is created if it doesn't exist yet,
and adds a test for the `CompletionCommand` to verify it works both
when the `PACK_HOME` directory exists and when it doesn't.

FIXES #272 