### PR TITLE
Validate buildpack API version

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -81,7 +81,15 @@ func TestAcceptance(t *testing.T) {
 
 	previousPackPath := os.Getenv(envPreviousPackPath)
 
-	lifecycleDescriptor := builder.DefaultLifecycleDescriptor()
+	lifecycleDescriptor := builder.LifecycleDescriptor{
+		Info: builder.LifecycleInfo{
+			Version: builder.VersionMustParse(builder.DefaultLifecycleVersion),
+		},
+		API: builder.LifecycleAPI{
+			BuildpackVersion: api.MustParse(builder.DefaultBuildpackAPIVersion),
+			PlatformVersion:  api.MustParse(builder.DefaultPlatformAPIVersion),
+		},
+	}
 	lifecyclePath := os.Getenv(envLifecyclePath)
 	if lifecyclePath != "" {
 		lifecyclePath, err = filepath.Abs(lifecyclePath)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -81,7 +81,7 @@ func TestAcceptance(t *testing.T) {
 
 	previousPackPath := os.Getenv(envPreviousPackPath)
 
-	lifecycleDescriptor := builder.AssumedLifecycleDescriptor
+	lifecycleDescriptor := builder.DefaultLifecycleDescriptor()
 	lifecyclePath := os.Getenv(envLifecyclePath)
 	if lifecyclePath != "" {
 		lifecyclePath, err = filepath.Abs(lifecyclePath)

--- a/acceptance/testdata/mock_buildpacks/0.2/noop-buildpack/buildpack.toml
+++ b/acceptance/testdata/mock_buildpacks/0.2/noop-buildpack/buildpack.toml
@@ -1,3 +1,5 @@
+api = "0.2"
+
 [buildpack]
   id = "noop.buildpack"
   version = "noop.buildpack.version"

--- a/acceptance/testdata/mock_buildpacks/0.2/not-in-builder-buildpack/buildpack.toml
+++ b/acceptance/testdata/mock_buildpacks/0.2/not-in-builder-buildpack/buildpack.toml
@@ -1,3 +1,5 @@
+api = "0.2"
+
 [buildpack]
   id = "local/bp"
   version = "local-bp-version"

--- a/acceptance/testdata/mock_buildpacks/0.2/other-stack-buildpack/buildpack.toml
+++ b/acceptance/testdata/mock_buildpacks/0.2/other-stack-buildpack/buildpack.toml
@@ -1,3 +1,5 @@
+api = "0.2"
+
 [buildpack]
   id = "other/stack/bp"
   version = "other-stack-version"

--- a/acceptance/testdata/mock_buildpacks/0.2/read-env-buildpack/buildpack.toml
+++ b/acceptance/testdata/mock_buildpacks/0.2/read-env-buildpack/buildpack.toml
@@ -1,3 +1,5 @@
+api = "0.2"
+
 [buildpack]
   id = "read/env"
   version = "read-env-version"

--- a/acceptance/testdata/mock_buildpacks/0.2/simple-layers-buildpack/buildpack.toml
+++ b/acceptance/testdata/mock_buildpacks/0.2/simple-layers-buildpack/buildpack.toml
@@ -1,3 +1,5 @@
+api = "0.2"
+
 [buildpack]
   id = "simple/layers"
   version = "simple-layers-version"

--- a/api/version.go
+++ b/api/version.go
@@ -76,3 +76,56 @@ func (v *Version) UnmarshalText(text []byte) error {
 
 	return nil
 }
+
+// SupportsVersion determines whether the argument version is compatible based on matching `major` version with the
+// exception of pre-stable version. Any version with `major` equal to 0 is not compatible if `minor` value does not
+// match.
+func (v *Version) SupportsVersion(v2 *Version) bool {
+	if v.Compare(v2) == 0 {
+		return true
+	}
+
+	if v != nil && v2 != nil {
+		if v.major > 0 && v.major == v2.major {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (v *Version) Compare(v2 *Version) int {
+	if v == nil && v2 == nil {
+		return 0
+	}
+
+	if v == nil {
+		return -1
+	}
+
+	if v2 == nil {
+		return 1
+	}
+
+	if v.major != v2.major {
+		if v.major < v2.major {
+			return -1
+		}
+
+		if v.major > v2.major {
+			return 1
+		}
+	}
+
+	if v.minor != v2.minor {
+		if v.minor < v2.minor {
+			return -1
+		}
+
+		if v.minor > v2.minor {
+			return 1
+		}
+	}
+
+	return 0
+}

--- a/api/version.go
+++ b/api/version.go
@@ -77,56 +77,42 @@ func (v *Version) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// SupportsVersion determines whether the argument version is compatible based on matching `major` version with the
-// exception of pre-stable version. Any version with `major` equal to 0 is not compatible if `minor` value does not
-// match.
-func (v *Version) SupportsVersion(v2 *Version) bool {
-	if v.Compare(v2) == 0 {
+// SupportsVersion determines whether this version supports a given version. If comparing two pre-stable (major == 0)
+// versions, minors must match exactly. Otherwise, this minor must be greater than or equal to the given minor. Majors
+// must always match.
+func (v *Version) SupportsVersion(o *Version) bool {
+	if v.Equal(o) {
 		return true
 	}
 
-	if v != nil && v2 != nil {
-		if v.major > 0 && v.major == v2.major {
-			return true
-		}
+	if v.major != 0 {
+		return v.major == o.major && v.minor >= o.minor
 	}
 
 	return false
 }
 
-func (v *Version) Equal(v2 *Version) bool {
-	return v.Compare(v2) == 0
+func (v *Version) Equal(o *Version) bool {
+	return v.Compare(o) == 0
 }
 
-func (v *Version) Compare(v2 *Version) int {
-	if v == nil && v2 == nil {
-		return 0
-	}
-
-	if v == nil {
-		return -1
-	}
-
-	if v2 == nil {
-		return 1
-	}
-
-	if v.major != v2.major {
-		if v.major < v2.major {
+func (v *Version) Compare(o *Version) int {
+	if v.major != o.major {
+		if v.major < o.major {
 			return -1
 		}
 
-		if v.major > v2.major {
+		if v.major > o.major {
 			return 1
 		}
 	}
 
-	if v.minor != v2.minor {
-		if v.minor < v2.minor {
+	if v.minor != o.minor {
+		if v.minor < o.minor {
 			return -1
 		}
 
-		if v.minor > v2.minor {
+		if v.minor > o.minor {
 			return 1
 		}
 	}

--- a/api/version.go
+++ b/api/version.go
@@ -94,6 +94,10 @@ func (v *Version) SupportsVersion(v2 *Version) bool {
 	return false
 }
 
+func (v *Version) Equal(v2 *Version) bool {
+	return v.Compare(v2) == 0
+}
+
 func (v *Version) Compare(v2 *Version) int {
 	if v == nil && v2 == nil {
 		return 0

--- a/api/version_test.go
+++ b/api/version_test.go
@@ -32,59 +32,64 @@ func testAPIVersion(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#SupportsVersion", func() {
-		it("is none-stable with matching minor value", func() {
-			subject := api.MustParse("0.2")
-			comparison := api.MustParse("0.2")
+		when("pre-stable", func() {
+			it("matching minor value", func() {
+				subject := api.MustParse("0.2")
+				comparison := api.MustParse("0.2")
 
-			h.AssertEq(t, subject.SupportsVersion(comparison), true)
-		})
-		it("is none-stable with subject minor > comparison minor", func() {
-			subject := api.MustParse("0.2")
-			comparison := api.MustParse("0.1")
+				h.AssertEq(t, subject.SupportsVersion(comparison), true)
+			})
 
-			h.AssertEq(t, subject.SupportsVersion(comparison), false)
-		})
+			it("subject minor > comparison minor", func() {
+				subject := api.MustParse("0.2")
+				comparison := api.MustParse("0.1")
 
-		it("is none-stable with subject minor < comparison minor", func() {
-			subject := api.MustParse("0.1")
-			comparison := api.MustParse("0.2")
+				h.AssertEq(t, subject.SupportsVersion(comparison), false)
+			})
 
-			h.AssertEq(t, subject.SupportsVersion(comparison), false)
-		})
+			it("subject minor < comparison minor", func() {
+				subject := api.MustParse("0.1")
+				comparison := api.MustParse("0.2")
 
-		it("is stable with matching major and minor", func() {
-			subject := api.MustParse("1.2")
-			comparison := api.MustParse("1.2")
-
-			h.AssertEq(t, subject.SupportsVersion(comparison), true)
+				h.AssertEq(t, subject.SupportsVersion(comparison), false)
+			})
 		})
 
-		it("is stable with matching major but minor > comparison minor", func() {
-			subject := api.MustParse("1.2")
-			comparison := api.MustParse("1.1")
+		when("stable", func() {
+			it("matching major and minor", func() {
+				subject := api.MustParse("1.2")
+				comparison := api.MustParse("1.2")
 
-			h.AssertEq(t, subject.SupportsVersion(comparison), true)
-		})
+				h.AssertEq(t, subject.SupportsVersion(comparison), true)
+			})
 
-		it("is stable with matching major but minor < comparison minor", func() {
-			subject := api.MustParse("1.1")
-			comparison := api.MustParse("1.2")
+			it("matching major but minor > comparison minor", func() {
+				subject := api.MustParse("1.2")
+				comparison := api.MustParse("1.1")
 
-			h.AssertEq(t, subject.SupportsVersion(comparison), true)
-		})
+				h.AssertEq(t, subject.SupportsVersion(comparison), true)
+			})
 
-		it("is stable with major < comparison major", func() {
-			subject := api.MustParse("1.0")
-			comparison := api.MustParse("2.0")
+			it("matching major but minor < comparison minor", func() {
+				subject := api.MustParse("1.1")
+				comparison := api.MustParse("1.2")
 
-			h.AssertEq(t, subject.SupportsVersion(comparison), false)
-		})
+				h.AssertEq(t, subject.SupportsVersion(comparison), false)
+			})
 
-		it("is stable with major > comparison major", func() {
-			subject := api.MustParse("2.0")
-			comparison := api.MustParse("1.0")
+			it("major < comparison major", func() {
+				subject := api.MustParse("1.0")
+				comparison := api.MustParse("2.0")
 
-			h.AssertEq(t, subject.SupportsVersion(comparison), false)
+				h.AssertEq(t, subject.SupportsVersion(comparison), false)
+			})
+
+			it("major > comparison major", func() {
+				subject := api.MustParse("2.0")
+				comparison := api.MustParse("1.0")
+
+				h.AssertEq(t, subject.SupportsVersion(comparison), false)
+			})
 		})
 	})
 }

--- a/api/version_test.go
+++ b/api/version_test.go
@@ -1,0 +1,74 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpack/pack/api"
+	h "github.com/buildpack/pack/testhelpers"
+)
+
+func TestAPIVersion(t *testing.T) {
+	spec.Run(t, "APIVersion", testAPIVersion, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testAPIVersion(t *testing.T, when spec.G, it spec.S) {
+	when("#SupportsVersion", func() {
+		it("is none-stable with matching minor value", func() {
+			subject := api.MustParse("0.2")
+			comparison := api.MustParse("0.2")
+
+			h.AssertEq(t, subject.SupportsVersion(comparison), true)
+		})
+		it("is none-stable with subject minor > comparison minor", func() {
+			subject := api.MustParse("0.2")
+			comparison := api.MustParse("0.1")
+
+			h.AssertEq(t, subject.SupportsVersion(comparison), false)
+		})
+
+		it("is none-stable with subject minor < comparison minor", func() {
+			subject := api.MustParse("0.1")
+			comparison := api.MustParse("0.2")
+
+			h.AssertEq(t, subject.SupportsVersion(comparison), false)
+		})
+
+		it("is stable with matching major and minor", func() {
+			subject := api.MustParse("1.2")
+			comparison := api.MustParse("1.2")
+
+			h.AssertEq(t, subject.SupportsVersion(comparison), true)
+		})
+
+		it("is stable with matching major but minor > comparison minor", func() {
+			subject := api.MustParse("1.2")
+			comparison := api.MustParse("1.1")
+
+			h.AssertEq(t, subject.SupportsVersion(comparison), true)
+		})
+
+		it("is stable with matching major but minor < comparison minor", func() {
+			subject := api.MustParse("1.1")
+			comparison := api.MustParse("1.2")
+
+			h.AssertEq(t, subject.SupportsVersion(comparison), true)
+		})
+
+		it("is stable with major < comparison major", func() {
+			subject := api.MustParse("1.0")
+			comparison := api.MustParse("2.0")
+
+			h.AssertEq(t, subject.SupportsVersion(comparison), false)
+		})
+
+		it("is stable with major > comparison major", func() {
+			subject := api.MustParse("2.0")
+			comparison := api.MustParse("1.0")
+
+			h.AssertEq(t, subject.SupportsVersion(comparison), false)
+		})
+	})
+}

--- a/api/version_test.go
+++ b/api/version_test.go
@@ -15,6 +15,22 @@ func TestAPIVersion(t *testing.T) {
 }
 
 func testAPIVersion(t *testing.T, when spec.G, it spec.S) {
+	when("#Equal", func() {
+		it("is equal to comparison", func() {
+			subject := api.MustParse("0.2")
+			comparison := api.MustParse("0.2")
+
+			h.AssertEq(t, subject.Equal(comparison), true)
+		})
+
+		it("is not equal to comparison", func() {
+			subject := api.MustParse("0.2")
+			comparison := api.MustParse("0.3")
+
+			h.AssertEq(t, subject.Equal(comparison), false)
+		})
+	})
+
 	when("#SupportsVersion", func() {
 		it("is none-stable with matching minor value", func() {
 			subject := api.MustParse("0.2")

--- a/build.go
+++ b/build.go
@@ -80,12 +80,12 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		return errors.Wrapf(err, "invalid run-image '%s'", runImage)
 	}
 
-	extraBuildpacks, group, err := c.processBuildpacks(opts.Buildpacks)
+	fetchedBps, group, err := c.processBuildpacks(opts.Buildpacks)
 	if err != nil {
 		return errors.Wrap(err, "invalid buildpack")
 	}
 
-	ephemeralBuilder, err := c.createEphemeralBuilder(rawBuilderImage, opts.Env, group, extraBuildpacks)
+	ephemeralBuilder, err := c.createEphemeralBuilder(rawBuilderImage, opts.Env, group, fetchedBps)
 	if err != nil {
 		return err
 	}
@@ -209,9 +209,9 @@ func (c *Client) processProxyConfig(config *ProxyConfig) ProxyConfig {
 	}
 }
 
-func (c *Client) processBuildpacks(buildpacks []string) ([]builder.Buildpack, builder.OrderEntry, error) {
+func (c *Client) processBuildpacks(buildpacks []string) ([]builder.AdditionalBuildpack, builder.OrderEntry, error) {
 	group := builder.OrderEntry{Group: []builder.BuildpackRef{}}
-	var bps []builder.Buildpack
+	var bps []builder.AdditionalBuildpack
 	for _, bp := range buildpacks {
 		if isBuildpackID(bp) {
 			id, version := c.parseBuildpack(bp)
@@ -239,7 +239,11 @@ func (c *Client) processBuildpacks(buildpacks []string) ([]builder.Buildpack, bu
 				return nil, builder.OrderEntry{}, errors.Wrapf(err, "creating buildpack from %s", style.Symbol(bp))
 			}
 
-			bps = append(bps, fetchedBP)
+			bps = append(bps, builder.AdditionalBuildpack{
+				Source:    bp,
+				Buildpack: fetchedBP,
+			})
+
 			group.Group = append(group.Group, builder.BuildpackRef{
 				BuildpackInfo: fetchedBP.Descriptor().Info,
 			})
@@ -302,7 +306,7 @@ func (c *Client) parseBuildpack(bp string) (string, string) {
 	return parts[0], ""
 }
 
-func (c *Client) createEphemeralBuilder(rawBuilderImage imgutil.Image, env map[string]string, group builder.OrderEntry, buildpacks []builder.Buildpack) (*builder.Builder, error) {
+func (c *Client) createEphemeralBuilder(rawBuilderImage imgutil.Image, env map[string]string, group builder.OrderEntry, buildpacks []builder.AdditionalBuildpack) (*builder.Builder, error) {
 	origBuilderName := rawBuilderImage.Name()
 	bldr, err := builder.New(rawBuilderImage, fmt.Sprintf("pack.local/builder/%x:latest", randString(10)))
 	if err != nil {

--- a/build.go
+++ b/build.go
@@ -209,9 +209,9 @@ func (c *Client) processProxyConfig(config *ProxyConfig) ProxyConfig {
 	}
 }
 
-func (c *Client) processBuildpacks(buildpacks []string) ([]builder.AdditionalBuildpack, builder.OrderEntry, error) {
+func (c *Client) processBuildpacks(buildpacks []string) ([]builder.Buildpack, builder.OrderEntry, error) {
 	group := builder.OrderEntry{Group: []builder.BuildpackRef{}}
-	var bps []builder.AdditionalBuildpack
+	var bps []builder.Buildpack
 	for _, bp := range buildpacks {
 		if isBuildpackID(bp) {
 			id, version := c.parseBuildpack(bp)
@@ -239,10 +239,7 @@ func (c *Client) processBuildpacks(buildpacks []string) ([]builder.AdditionalBui
 				return nil, builder.OrderEntry{}, errors.Wrapf(err, "creating buildpack from %s", style.Symbol(bp))
 			}
 
-			bps = append(bps, builder.AdditionalBuildpack{
-				Source:    bp,
-				Buildpack: fetchedBP,
-			})
+			bps = append(bps, fetchedBP)
 
 			group.Group = append(group.Group, builder.BuildpackRef{
 				BuildpackInfo: fetchedBP.Descriptor().Info,
@@ -306,7 +303,7 @@ func (c *Client) parseBuildpack(bp string) (string, string) {
 	return parts[0], ""
 }
 
-func (c *Client) createEphemeralBuilder(rawBuilderImage imgutil.Image, env map[string]string, group builder.OrderEntry, buildpacks []builder.AdditionalBuildpack) (*builder.Builder, error) {
+func (c *Client) createEphemeralBuilder(rawBuilderImage imgutil.Image, env map[string]string, group builder.OrderEntry, buildpacks []builder.Buildpack) (*builder.Builder, error) {
 	origBuilderName := rawBuilderImage.Name()
 	bldr, err := builder.New(rawBuilderImage, fmt.Sprintf("pack.local/builder/%x:latest", randString(10)))
 	if err != nil {

--- a/build/build.go
+++ b/build/build.go
@@ -71,8 +71,8 @@ func (l *Lifecycle) Execute(ctx context.Context, opts LifecycleOptions) error {
 
 	lifecycleVersion := l.builder.GetLifecycleDescriptor().Info.Version
 	if lifecycleVersion == nil {
-		l.logger.Warn("lifecycle version unknown")
-		lifecycleVersion = builder.AssumedLifecycleDescriptor().Info.Version
+		l.logger.Warnf("lifecycle version unknown, assuming %s", style.Symbol(builder.AssumedLifecycleVersion))
+		lifecycleVersion = builder.VersionMustParse(builder.AssumedLifecycleVersion)
 	} else {
 		l.logger.Debugf("Executing lifecycle version %s", style.Symbol(lifecycleVersion.String()))
 	}

--- a/build/build.go
+++ b/build/build.go
@@ -16,10 +16,6 @@ import (
 	"github.com/buildpack/pack/style"
 )
 
-const (
-	DefaultLifecycleVersion = "0.3.0"
-)
-
 type Lifecycle struct {
 	builder      *builder.Builder
 	logger       logging.Logger
@@ -76,7 +72,7 @@ func (l *Lifecycle) Execute(ctx context.Context, opts LifecycleOptions) error {
 	lifecycleVersion := l.builder.GetLifecycleDescriptor().Info.Version
 	if lifecycleVersion == nil {
 		l.logger.Warn("lifecycle version unknown")
-		lifecycleVersion = builder.AssumedLifecycleDescriptor.Info.Version
+		lifecycleVersion = builder.AssumedLifecycleDescriptor().Info.Version
 	} else {
 		l.logger.Debugf("Executing lifecycle version %s", style.Symbol(lifecycleVersion.String()))
 	}

--- a/build_test.go
+++ b/build_test.go
@@ -600,51 +600,6 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, os.Remove(buildpackTgz))
 				})
 
-				when("buildpack is an older api version", func() {
-					var (
-						incompatibleBuildpackTGZ *os.File
-						err                      error
-					)
-
-					it.Before(func() {
-						incompatibleBuildpackTGZ, err = ifakes.CreateBuildpackTGZ(tmpDir, builder.BuildpackDescriptor{
-							API: api.MustParse("0.9"),
-							Info: builder.BuildpackInfo{
-								ID:      "incompatible.id",
-								Version: "incompatible.id.version",
-							},
-							Stacks: []builder.Stack{
-								{
-									ID: "some.stack.id",
-								},
-							},
-							Order: nil,
-						})
-
-						h.AssertNil(t, err)
-					})
-
-					it("should error", func() {
-						err := subject.Build(context.TODO(), BuildOptions{
-							Image:      "some/app",
-							Builder:    builderName,
-							ClearCache: true,
-							Buildpacks: []string{
-								"buildpack.id@buildpack.version",
-								incompatibleBuildpackTGZ.Name(),
-							},
-						})
-
-						h.AssertError(t, err, fmt.Sprintf(
-							"buildpack from URI '%s' (Buildpack API version %s) is incompatible with lifecycle '%s' (Buildpack API version %s)",
-							incompatibleBuildpackTGZ.Name(),
-							"0.9",
-							"0.3.0",
-							"0.3",
-						))
-					})
-				})
-
 				when("is windows", func() {
 					it.Before(func() {
 						h.SkipIf(t, runtime.GOOS != "windows", "Skipped on non-windows")

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -18,6 +18,7 @@ import (
 	"github.com/buildpack/imgutil"
 	"github.com/pkg/errors"
 
+	"github.com/buildpack/pack/api"
 	"github.com/buildpack/pack/internal/archive"
 	"github.com/buildpack/pack/style"
 )
@@ -502,10 +503,13 @@ func (b *Builder) orderLayer(dest string) (string, error) {
 
 func (b *Builder) orderFileContents() (string, error) {
 	buf := &bytes.Buffer{}
-	lifecycleVersion := b.GetLifecycleDescriptor().Info.Version
+	bpAPIVersion := AssumedLifecycleDescriptor().API.BuildpackVersion
+	if b.GetLifecycleDescriptor().Info.Version != nil {
+		bpAPIVersion = b.GetLifecycleDescriptor().API.BuildpackVersion
+	}
 
 	var tomlData interface{}
-	if lifecycleVersion != nil && lifecycleVersion.LessThan(&v0_4_0) {
+	if bpAPIVersion.Equal(api.MustParse("0.1")) {
 		tomlData = v1OrderTOML{Groups: b.metadata.Groups}
 	} else {
 		tomlData = orderTOML{Order: b.order}

--- a/builder/buildpack.go
+++ b/builder/buildpack.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/buildpack/pack/style"
-
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
 
+	"github.com/buildpack/pack/api"
 	"github.com/buildpack/pack/internal/archive"
+	"github.com/buildpack/pack/style"
 )
 
 type buildpack struct {
@@ -22,6 +22,7 @@ func (b *buildpack) Descriptor() BuildpackDescriptor {
 }
 
 type BuildpackDescriptor struct {
+	API    *api.Version  `toml:"api"`
 	Info   BuildpackInfo `toml:"buildpack"`
 	Stacks []Stack       `toml:"stacks"`
 	Order  Order         `toml:"order"`
@@ -55,6 +56,7 @@ func NewBuildpack(blob Blob) (Buildpack, error) {
 		return nil, errors.Wrapf(err, "reading buildpack.toml")
 	}
 
+	bpd.API = AssumedLifecycleDescriptor().API.BuildpackVersion
 	_, err = toml.Decode(string(buf), &bpd)
 	if err != nil {
 		return nil, errors.Wrapf(err, "decoding buildpack.toml")

--- a/builder/buildpack.go
+++ b/builder/buildpack.go
@@ -56,7 +56,7 @@ func NewBuildpack(blob Blob) (Buildpack, error) {
 		return nil, errors.Wrapf(err, "reading buildpack.toml")
 	}
 
-	bpd.API = AssumedLifecycleDescriptor().API.BuildpackVersion
+	bpd.API = api.MustParse(AssumedBuildpackAPIVersion)
 	_, err = toml.Decode(string(buf), &bpd)
 	if err != nil {
 		return nil, errors.Wrapf(err, "decoding buildpack.toml")

--- a/builder/compat.go
+++ b/builder/compat.go
@@ -121,7 +121,7 @@ func (b *Builder) compatBuildpacks(tw *tar.Writer) error {
 		}
 
 		lcVersion := b.lifecycleDescriptor.Info.Version
-		if lcVersion != nil && lcVersion.LessThan(v0_4_0) {
+		if lcVersion != nil && lcVersion.LessThan(&v0_4_0) {
 			if err := symlinkLatest(tw, bpDir, descriptor, b.metadata); err != nil {
 				return err
 			}

--- a/builder/compat.go
+++ b/builder/compat.go
@@ -11,6 +11,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
 
+	"github.com/buildpack/pack/api"
 	"github.com/buildpack/pack/internal/archive"
 	"github.com/buildpack/pack/style"
 )
@@ -120,8 +121,8 @@ func (b *Builder) compatBuildpacks(tw *tar.Writer) error {
 			return err
 		}
 
-		lcVersion := b.lifecycleDescriptor.Info.Version
-		if lcVersion != nil && lcVersion.LessThan(&v0_4_0) {
+		bpAPIVersion := b.lifecycleDescriptor.API.BuildpackVersion
+		if bpAPIVersion != nil && bpAPIVersion.Equal(api.MustParse("0.1")) {
 			if err := symlinkLatest(tw, bpDir, descriptor, b.metadata); err != nil {
 				return err
 			}

--- a/builder/compat_test.go
+++ b/builder/compat_test.go
@@ -32,10 +32,10 @@ func testCompat(t *testing.T, when spec.G, it spec.S) {
 		subject        *builder.Builder
 		mockController *gomock.Controller
 		mockLifecycle  *testmocks.MockLifecycle
-		bp1v1          builder.AdditionalBuildpack
-		bp1v2          builder.AdditionalBuildpack
-		bp2v1          builder.AdditionalBuildpack
-		bpOrder        builder.AdditionalBuildpack
+		bp1v1          builder.Buildpack
+		bp1v2          builder.Buildpack
+		bp2v1          builder.Buildpack
+		bpOrder        builder.Buildpack
 	)
 
 	it.Before(func() {
@@ -46,31 +46,31 @@ func testCompat(t *testing.T, when spec.G, it spec.S) {
 		mockLifecycle.EXPECT().Open().Return(archive.ReadDirAsTar(
 			filepath.Join("testdata", "lifecycle"), ".", 0, 0, -1), nil).AnyTimes()
 
-		bp1v1 = builder.AdditionalBuildpack{Buildpack: &fakeBuildpack{descriptor: builder.BuildpackDescriptor{
+		bp1v1 = &fakeBuildpack{descriptor: builder.BuildpackDescriptor{
 			API: api.MustParse("0.1"),
 			Info: builder.BuildpackInfo{
 				ID:      "buildpack-1-id",
 				Version: "buildpack-1-version-1",
 			},
 			Stacks: []builder.Stack{{ID: "some.stack.id"}},
-		}}}
-		bp1v2 = builder.AdditionalBuildpack{Buildpack: &fakeBuildpack{descriptor: builder.BuildpackDescriptor{
+		}}
+		bp1v2 = &fakeBuildpack{descriptor: builder.BuildpackDescriptor{
 			API: api.MustParse("0.1"),
 			Info: builder.BuildpackInfo{
 				ID:      "buildpack-1-id",
 				Version: "buildpack-1-version-2",
 			},
 			Stacks: []builder.Stack{{ID: "some.stack.id"}},
-		}}}
-		bp2v1 = builder.AdditionalBuildpack{Buildpack: &fakeBuildpack{descriptor: builder.BuildpackDescriptor{
+		}}
+		bp2v1 = &fakeBuildpack{descriptor: builder.BuildpackDescriptor{
 			API: api.MustParse("0.1"),
 			Info: builder.BuildpackInfo{
 				ID:      "buildpack-2-id",
 				Version: "buildpack-2-version-1",
 			},
 			Stacks: []builder.Stack{{ID: "some.stack.id"}},
-		}}}
-		bpOrder = builder.AdditionalBuildpack{Buildpack: &fakeBuildpack{descriptor: builder.BuildpackDescriptor{
+		}}
+		bpOrder = &fakeBuildpack{descriptor: builder.BuildpackDescriptor{
 			API: api.MustParse("0.1"),
 			Info: builder.BuildpackInfo{
 				ID:      "order-buildpack-id",
@@ -88,7 +88,7 @@ func testCompat(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			}},
-		}}}
+		}}
 
 		h.AssertNil(t, baseImage.SetEnv("CNB_USER_ID", "1234"))
 		h.AssertNil(t, baseImage.SetEnv("CNB_GROUP_ID", "4321"))
@@ -364,16 +364,13 @@ func testCompat(t *testing.T, when spec.G, it spec.S) {
 	})
 }
 
-func updateFakeAPIVersion(buildpack builder.AdditionalBuildpack, version *api.Version) builder.AdditionalBuildpack {
-	return builder.AdditionalBuildpack{
-		Source: buildpack.Source,
-		Buildpack: &fakeBuildpack{
-			descriptor: builder.BuildpackDescriptor{
-				API:    version,
-				Info:   buildpack.Descriptor().Info,
-				Stacks: buildpack.Descriptor().Stacks,
-				Order:  buildpack.Descriptor().Order,
-			},
+func updateFakeAPIVersion(buildpack builder.Buildpack, version *api.Version) builder.Buildpack {
+	return &fakeBuildpack{
+		descriptor: builder.BuildpackDescriptor{
+			API:    version,
+			Info:   buildpack.Descriptor().Info,
+			Stacks: buildpack.Descriptor().Stacks,
+			Order:  buildpack.Descriptor().Order,
 		},
 	}
 }

--- a/builder/lifecycle.go
+++ b/builder/lifecycle.go
@@ -16,44 +16,42 @@ import (
 )
 
 var (
-	apiVersionAssumed = api.MustParse("0.1")
-	apiVersionLatest  = api.MustParse("0.2")
+	v0_3_0 = *semver.MustParse("0.3.0")
+	v0_4_0 = *semver.MustParse("0.4.0")
 
-	v0_3_0 = semver.MustParse("0.3.0")
-	v0_4_0 = semver.MustParse("0.4.0")
-
-	lifecycleVersionAssumed = &Version{Version: *v0_3_0}
-	lifecycleVersionLatest  = &Version{Version: *v0_4_0}
+	lifecycleBinaries = []string{
+		"detector",
+		"restorer",
+		"analyzer",
+		"builder",
+		"exporter",
+		"cacher",
+		"launcher",
+	}
 )
 
-var AssumedLifecycleDescriptor = LifecycleDescriptor{
-	Info: LifecycleInfo{
-		Version: lifecycleVersionAssumed,
-	},
-	API: LifecycleAPI{
-		PlatformVersion:  apiVersionAssumed,
-		BuildpackVersion: apiVersionAssumed,
-	},
+func AssumedLifecycleDescriptor() LifecycleDescriptor {
+	return LifecycleDescriptor{
+		Info: LifecycleInfo{
+			Version: &Version{Version: v0_3_0},
+		},
+		API: LifecycleAPI{
+			PlatformVersion:  api.MustParse("0.1"),
+			BuildpackVersion: api.MustParse("0.1"),
+		},
+	}
 }
 
-var LatestLifecycleDescriptor = LifecycleDescriptor{
-	Info: LifecycleInfo{
-		Version: lifecycleVersionLatest,
-	},
-	API: LifecycleAPI{
-		PlatformVersion:  apiVersionLatest,
-		BuildpackVersion: apiVersionLatest,
-	},
-}
-
-var lifecycleBinaries = []string{
-	"detector",
-	"restorer",
-	"analyzer",
-	"builder",
-	"exporter",
-	"cacher",
-	"launcher",
+func DefaultLifecycleDescriptor() LifecycleDescriptor {
+	return LifecycleDescriptor{
+		Info: LifecycleInfo{
+			Version: &Version{Version: v0_3_0},
+		},
+		API: LifecycleAPI{
+			PlatformVersion:  api.MustParse("0.1"),
+			BuildpackVersion: api.MustParse("0.1"),
+		},
+	}
 }
 
 type Blob interface {
@@ -101,7 +99,8 @@ func NewLifecycle(blob Blob) (Lifecycle, error) {
 	if err != nil && errors.Cause(err) == archive.ErrEntryNotExist {
 		return &lifecycle{
 			Blob:       blob,
-			descriptor: AssumedLifecycleDescriptor}, nil
+			descriptor: AssumedLifecycleDescriptor(),
+		}, nil
 	} else if err != nil {
 		return nil, errors.Wrap(err, "decode lifecycle descriptor")
 	}

--- a/builder/version.go
+++ b/builder/version.go
@@ -10,6 +10,10 @@ type Version struct {
 	semver.Version
 }
 
+func VersionMustParse(v string) *Version {
+	return &Version{Version: *semver.MustParse(v)}
+}
+
 func (v *Version) String() string {
 	return v.Version.String()
 }

--- a/commands/inspect_builder.go
+++ b/commands/inspect_builder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/buildpack/pack"
+	"github.com/buildpack/pack/api"
 	"github.com/buildpack/pack/builder"
 	"github.com/buildpack/pack/config"
 	"github.com/buildpack/pack/logging"
@@ -77,21 +78,19 @@ func inspectBuilderOutput(logger logging.Logger, client PackClient, imageName st
 	logger.Infof("Stack: %s", info.Stack)
 	logger.Info("")
 
-	assumedDescriptor := builder.AssumedLifecycleDescriptor()
-
 	lcVersion := info.Lifecycle.Info.Version
 	if info.Lifecycle.Info.Version == nil {
-		lcVersion = assumedDescriptor.Info.Version
+		lcVersion = builder.VersionMustParse(builder.AssumedLifecycleVersion)
 	}
 
 	apiBpVersion := info.Lifecycle.API.BuildpackVersion
 	if info.Lifecycle.API.BuildpackVersion == nil {
-		apiBpVersion = assumedDescriptor.API.BuildpackVersion
+		apiBpVersion = api.MustParse(builder.AssumedBuildpackAPIVersion)
 	}
 
 	apiPlatformVersion := info.Lifecycle.API.PlatformVersion
 	if info.Lifecycle.API.PlatformVersion == nil {
-		apiPlatformVersion = assumedDescriptor.API.PlatformVersion
+		apiPlatformVersion = api.MustParse(builder.AssumedPlatformAPIVersion)
 	}
 
 	logger.Info("Lifecycle:")

--- a/commands/inspect_builder.go
+++ b/commands/inspect_builder.go
@@ -77,19 +77,21 @@ func inspectBuilderOutput(logger logging.Logger, client PackClient, imageName st
 	logger.Infof("Stack: %s", info.Stack)
 	logger.Info("")
 
+	assumedDescriptor := builder.AssumedLifecycleDescriptor()
+
 	lcVersion := info.Lifecycle.Info.Version
 	if info.Lifecycle.Info.Version == nil {
-		lcVersion = builder.AssumedLifecycleDescriptor.Info.Version
+		lcVersion = assumedDescriptor.Info.Version
 	}
 
 	apiBpVersion := info.Lifecycle.API.BuildpackVersion
 	if info.Lifecycle.API.BuildpackVersion == nil {
-		apiBpVersion = builder.AssumedLifecycleDescriptor.API.BuildpackVersion
+		apiBpVersion = assumedDescriptor.API.BuildpackVersion
 	}
 
 	apiPlatformVersion := info.Lifecycle.API.PlatformVersion
 	if info.Lifecycle.API.PlatformVersion == nil {
-		apiPlatformVersion = builder.AssumedLifecycleDescriptor.API.PlatformVersion
+		apiPlatformVersion = assumedDescriptor.API.PlatformVersion
 	}
 
 	logger.Info("Lifecycle:")

--- a/create_builder.go
+++ b/create_builder.go
@@ -82,10 +82,7 @@ func (c *Client) CreateBuilder(ctx context.Context, opts CreateBuilderOptions) e
 			return errors.Wrap(err, "invalid buildpack")
 		}
 
-		builderImage.AddBuildpack(builder.AdditionalBuildpack{
-			Source:    b.URI,
-			Buildpack: fetchedBp,
-		})
+		builderImage.AddBuildpack(fetchedBp)
 	}
 
 	builderImage.SetOrder(opts.BuilderConfig.Order)
@@ -135,7 +132,7 @@ func (c *Client) fetchLifecycle(config builder.LifecycleConfig) (builder.Lifecyc
 	} else if config.URI != "" {
 		uri = config.URI
 	} else {
-		uri = uriFromLifecycleVersion(builder.DefaultLifecycleDescriptor().Info.Version.Version)
+		uri = uriFromLifecycleVersion(*semver.MustParse(builder.AssumedLifecycleVersion))
 	}
 
 	b, err := c.downloader.Download(uri)

--- a/internal/fakes/fake_buildpack_blob.go
+++ b/internal/fakes/fake_buildpack_blob.go
@@ -1,0 +1,47 @@
+package fakes
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/buildpack/pack/builder"
+	"github.com/buildpack/pack/internal/archive"
+)
+
+type fakeBuildpackBlob struct {
+	tmpDir     string
+	descriptor builder.BuildpackDescriptor
+}
+
+func NewFakeBuildpackBlob(tmpDir string, descriptor builder.BuildpackDescriptor) *fakeBuildpackBlob {
+	return &fakeBuildpackBlob{
+		tmpDir:     tmpDir,
+		descriptor: descriptor,
+	}
+}
+
+func (b fakeBuildpackBlob) Open() (io.ReadCloser, error) {
+	return CreateBuildpackTGZ(b.tmpDir, b.descriptor)
+}
+
+func CreateBuildpackTGZ(tmpDir string, descriptor builder.BuildpackDescriptor) (*os.File, error) {
+	bpTmpFile, err := ioutil.TempFile(tmpDir, "bp-*.tgz")
+	if err != nil {
+		return nil, err
+	}
+
+	buf := &bytes.Buffer{}
+	if err = toml.NewEncoder(buf).Encode(descriptor); err != nil {
+		return nil, err
+	}
+
+	if err = archive.CreateSingleFileTar(bpTmpFile.Name(), "buildpack.toml", buf.String()); err != nil {
+		return nil, err
+	}
+
+	return bpTmpFile, nil
+}

--- a/internal/fakes/fake_images.go
+++ b/internal/fakes/fake_images.go
@@ -4,34 +4,17 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Masterminds/semver"
 	"github.com/buildpack/imgutil/fakes"
 
-	"github.com/buildpack/pack/build"
 	"github.com/buildpack/pack/builder"
 	h "github.com/buildpack/pack/testhelpers"
 )
 
-func NewFakeBuilderImage(t *testing.T, name string, buildpacks []builder.BuildpackMetadata, config builder.Config) *fakes.Image {
+func NewFakeBuilderImage(t *testing.T, name string, stackId, uid, gid string, metadata builder.Metadata) *fakes.Image {
 	fakeBuilderImage := fakes.NewImage(name, "", "")
-	h.AssertNil(t, fakeBuilderImage.SetLabel("io.buildpacks.stack.id", config.Stack.ID))
-	h.AssertNil(t, fakeBuilderImage.SetEnv("CNB_USER_ID", "1234"))
-	h.AssertNil(t, fakeBuilderImage.SetEnv("CNB_GROUP_ID", "4321"))
-	metadata := builder.Metadata{
-		Buildpacks: buildpacks,
-		Groups:     config.Order.ToV1Order(),
-		Stack: builder.StackMetadata{
-			RunImage: builder.RunImageMetadata{
-				Image:   config.Stack.RunImage,
-				Mirrors: config.Stack.RunImageMirrors,
-			},
-		},
-		Lifecycle: builder.LifecycleMetadata{
-			LifecycleInfo: builder.LifecycleInfo{
-				Version: &builder.Version{Version: *semver.MustParse(build.DefaultLifecycleVersion)},
-			},
-		},
-	}
+	h.AssertNil(t, fakeBuilderImage.SetLabel("io.buildpacks.stack.id", stackId))
+	h.AssertNil(t, fakeBuilderImage.SetEnv("CNB_USER_ID", uid))
+	h.AssertNil(t, fakeBuilderImage.SetEnv("CNB_GROUP_ID", gid))
 	label, err := json.Marshal(&metadata)
 	h.AssertNil(t, err)
 	h.AssertNil(t, fakeBuilderImage.SetLabel("io.buildpacks.builder.metadata", string(label)))

--- a/testdata/buildpack/buildpack.toml
+++ b/testdata/buildpack/buildpack.toml
@@ -1,3 +1,5 @@
+api = "0.3"
+
 [buildpack]
 id = "bp.one"
 version = "1.2.3"

--- a/testdata/buildpack2/buildpack.toml
+++ b/testdata/buildpack2/buildpack.toml
@@ -1,3 +1,5 @@
+api = "0.3"
+
 [buildpack]
 id = "some-other-buildpack-id"
 version = "some-other-buildpack-version"


### PR DESCRIPTION
Also:

* Default lifecycle during `create-builder` if no version or URI is specified
* Use BP API Version to determine `order.toml` format

Resolves #254
Resolves #284 

Signed-off-by: Javier Romero <jromero@pivotal.io>
Signed-off-by: Andrew Meyer <ameyer@pivotal.io>