### PR TITLE
when reading archives treat ./file like file

### DIFF
--- a/builder/buildpack_test.go
+++ b/builder/buildpack_test.go
@@ -100,11 +100,9 @@ id = "some.stack.id"
 				_, err := builder.NewBuildpack(blob.NewBlob(tmpBpDir))
 				h.AssertError(t, err, "cannot have both stacks and an order defined")
 			})
-
 		})
 
 		when("missing stacks and order", func() {
-
 			it.Before(func() {
 				h.AssertNil(t, ioutil.WriteFile(filepath.Join(tmpBpDir, "buildpack.toml"), []byte(`
 [buildpack]

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -143,7 +144,7 @@ func ReadTarEntry(rc io.Reader, entryPath string) (*tar.Header, []byte, error) {
 			return nil, nil, errors.Wrap(err, "failed to get next tar entry")
 		}
 
-		if header.Name == entryPath {
+		if path.Clean(header.Name) == entryPath {
 			buf, err := ioutil.ReadAll(tr)
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "failed to read contents of '%s'", entryPath)

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -53,13 +53,36 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 		it.Before(func() {
 			tarFile, err = ioutil.TempFile(tmpDir, "file.tgz")
 			h.AssertNil(t, err)
-
-			err = archive.CreateSingleFileTar(tarFile.Name(), "./file1", "file-1 content")
-			h.AssertNil(t, err)
 		})
 
 		it.After(func() {
 			_ = tarFile.Close()
+		})
+
+		when("tgz has the path", func() {
+			it.Before(func() {
+				err = archive.CreateSingleFileTar(tarFile.Name(), "file1", "file-1 content")
+				h.AssertNil(t, err)
+			})
+
+			it("returns the file contents", func() {
+				_, contents, err := archive.ReadTarEntry(tarFile, "file1")
+				h.AssertNil(t, err)
+				h.AssertEq(t, string(contents), "file-1 content")
+			})
+		})
+
+		when("tgz has ./path", func() {
+			it.Before(func() {
+				err = archive.CreateSingleFileTar(tarFile.Name(), "./file1", "file-1 content")
+				h.AssertNil(t, err)
+			})
+
+			it("returns the file contents", func() {
+				_, contents, err := archive.ReadTarEntry(tarFile, "file1")
+				h.AssertNil(t, err)
+				h.AssertEq(t, string(contents), "file-1 content")
+			})
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Emily Casey <ecasey@pivotal.io>
Signed-off-by: Micah Young <myoung@pivotal.io>