### PR TITLE
ANSI control characters are stripped from Windows builds

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -2,10 +2,10 @@
 package logging
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"sync"
 	"time"
 
@@ -17,6 +17,7 @@ import (
 const (
 	errorLevelText = "ERROR: "
 	warnLevelText  = "Warning: "
+	lineFeed       = '\n'
 
 	// time format the out logging uses
 	timeFmt = "2006/01/02 15:04:05.000000"
@@ -44,8 +45,8 @@ func formatLevel(ll log.Level) string {
 // preserve behavior of other loggers
 func appendMissingLineFeed(msg string) string {
 	buff := []byte(msg)
-	if buff[len(buff)-1] != '\n' {
-		buff = append(buff, '\n')
+	if buff[len(buff)-1] != lineFeed {
+		buff = append(buff, lineFeed)
 	}
 	return string(buff)
 }
@@ -112,9 +113,9 @@ func (lw *logWithWriters) WantQuiet(f bool) {
 }
 
 // NewLogWithWriters creates a logger to be used with pack CLI.
-func NewLogWithWriters() *logWithWriters {
+func NewLogWithWriters(stdout, stderr io.Writer) *logWithWriters {
 	hnd := &handler{
-		writer: os.Stdout,
+		writer: stdout,
 		timer: func() time.Time {
 			return time.Now()
 		},
@@ -122,8 +123,64 @@ func NewLogWithWriters() *logWithWriters {
 	var lw logWithWriters
 	lw.handler = hnd
 	lw.out = hnd.writer
-	lw.errOut = os.Stderr
+	lw.errOut = stderr
 	lw.Logger.Handler = hnd
 	lw.Logger.Level = log.DebugLevel
 	return &lw
+}
+
+// Writer wraps console output file descriptors and will optionally strip ANSI color codes from output.  The reason
+// this is needed is because build pack scripts are generally bash shell scripts and are executed on a docker container.
+// The output from these scripts often contain color codes and the docker api returns this raw console output to
+// pack code.  If pack is running on Windows, the output containing the color codes looks like crap.
+type Writer struct {
+	sync.Mutex
+	buffer bytes.Buffer
+	out    io.Writer
+}
+
+// New creates writer taking something that implements io.Writer as an argument.
+func New(w io.Writer) *Writer {
+	return &Writer{
+		out: w,
+	}
+}
+
+func write(w *Writer, b []byte) {
+	if len(b) == 0 {
+		return
+	}
+	i := bytes.IndexByte(b, lineFeed)
+	if i == -1 {
+		w.buffer.Write(b)
+		return
+	}
+	w.buffer.Write(b[:i+1])
+	_, _ = fmt.Fprint(w.out, maybeStripColor(w.buffer.Bytes()))
+	w.buffer.Reset()
+	write(w, b[i+1:])
+}
+
+// Write buffered input is written to the underlying io.Writer when a line feed occurs.
+func (w *Writer) Write(b []byte) (n int, err error) {
+	w.Lock()
+	defer w.Unlock()
+	n = len(b)
+	write(w, b)
+	return n, err
+}
+
+// Close writes any remaining buffer contents to underlying io.Writer
+func (w *Writer) Close() error {
+	w.Lock()
+	defer w.Unlock()
+	if w.buffer.Len() == 0 {
+		return nil
+	}
+	contents := maybeStripColor(w.buffer.Bytes())
+	if len(contents) > 0 {
+		_, err := fmt.Fprintln(w.out, contents)
+		return err
+	}
+	return nil
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"runtime"
 	"testing"
 	"time"
 
@@ -103,5 +104,184 @@ func TestPackCLILogger(t *testing.T) {
 			expected := "\n"
 			h.AssertEq(t, log.String(), expected)
 		})
+	})
+}
+
+func TestColor(t *testing.T) {
+	spec.Run(t, "writer", func(t *testing.T, when spec.G, it spec.S) {
+		var previousColorSetting bool
+		var wtr *Writer
+		var out bytes.Buffer
+
+		it.Before(func() {
+			previousColorSetting = color.NoColor
+			wtr = New(&out)
+		})
+
+		it.After(func() {
+			color.NoColor = previousColorSetting
+			out.Reset()
+		})
+
+		when("color enabled", func() {
+			it.Before(func() {
+				if runtime.GOOS == "windows" {
+					t.Skip("with color tests disabled on windows")
+				}
+				color.NoColor = false
+			})
+
+			it("should add color", func() {
+				writeLines(wtr,
+					color.RedString("line one "),
+					color.YellowString("line two\n"),
+				)
+				want := "\x1b[31mline one \x1b[0m\x1b[33mline two\n\x1b[0m\n"
+				got := out.String()
+				h.AssertEq(t, got, want)
+			})
+
+			it("should handle split lines", func() {
+				writeLines(wtr,
+					color.RedString("one\ntwo"),
+					"\nthree",
+				)
+				want := "\x1b[31mone\ntwo\x1b[0m\nthree\n"
+				got := out.String()
+				h.AssertEq(t, got, want)
+			})
+
+			it("should handle empty input", func() {
+				writeLines(wtr, "")
+				want := ""
+				got := out.String()
+				h.AssertEq(t, got, want)
+			})
+
+			it("should handle single line", func() {
+				writeLines(wtr, "a line\n")
+				want := "a line\n"
+				got := out.String()
+				h.AssertEq(t, got, want)
+			})
+
+		})
+
+		when("color disabled", func() {
+			it.Before(func() {
+				color.NoColor = true
+			})
+
+			it("should strip color", func() {
+				writeLines(wtr, color.RedString("line one "), color.YellowString("line two\n"))
+				want := "line one line two\n"
+				got := out.String()
+				h.AssertEq(t, got, want)
+			})
+
+			it("handles split lines", func() {
+				writeLines(wtr, color.RedString("one\ntwo"), "\nthree")
+				want := "one\ntwo\nthree\n"
+				got := out.String()
+				h.AssertEq(t, got, want)
+			})
+		})
+	})
+}
+
+func writeLines(w io.WriteCloser, lines ...string) {
+	for _, line := range lines {
+		_, _ = w.Write([]byte(line))
+	}
+	_ = w.Close()
+}
+
+func TestMaybeStripColors(t *testing.T) {
+	spec.Run(t, "combinations", func(t *testing.T, when spec.G, it spec.S) {
+		var originalColorSetting bool
+		it.Before(func() {
+			originalColorSetting = color.NoColor
+			color.NoColor = true
+		})
+		it.After(func() {
+			color.NoColor = originalColorSetting
+		})
+		it("should strip color", func() {
+			baseAttrs := []color.Attribute{
+				color.Reset,
+				color.Bold,
+				color.Faint,
+				color.Italic,
+				color.Underline,
+				color.BlinkSlow,
+				color.BlinkRapid,
+				color.ReverseVideo,
+				color.Concealed,
+				color.CrossedOut,
+			}
+			foregroundAttrs := []color.Attribute{
+				color.FgBlack,
+				color.FgRed,
+				color.FgGreen,
+				color.FgYellow,
+				color.FgBlue,
+				color.FgMagenta,
+				color.FgCyan,
+				color.FgWhite,
+				color.FgHiBlack,
+				color.FgHiRed,
+				color.FgHiGreen,
+				color.FgHiYellow,
+				color.FgHiBlue,
+				color.FgHiMagenta,
+				color.FgHiCyan,
+				color.FgHiWhite,
+			}
+			backgroundAttrs := []color.Attribute{
+				color.BgBlack,
+				color.BgRed,
+				color.BgGreen,
+				color.BgYellow,
+				color.BgBlue,
+				color.BgMagenta,
+				color.BgCyan,
+				color.BgWhite,
+				color.BgHiBlack,
+				color.BgHiRed,
+				color.BgHiGreen,
+				color.BgHiYellow,
+				color.BgHiBlue,
+				color.BgHiMagenta,
+				color.BgHiCyan,
+				color.BgHiWhite,
+			}
+			want := "Hello, 786 colorful\n[ ]; world."
+			testCombo := func(c *color.Color) {
+				var out bytes.Buffer
+				_, _ = c.Fprint(&out, want)
+				got := maybeStripColor(out.Bytes())
+				if got != want {
+					t.Logf("color %+v", *c)
+					t.Fatalf("got %q want %q", got, want)
+				}
+			}
+
+			for i := 0; i < len(baseAttrs); i++ {
+				testCombo(color.New(baseAttrs[i]))
+
+				for j := 0; j < len(foregroundAttrs); j++ {
+					testCombo(color.New(foregroundAttrs[j]))
+					testCombo(color.New(baseAttrs[i], foregroundAttrs[j]))
+
+					for k := 0; k < len(backgroundAttrs); k++ {
+						testCombo(color.New(backgroundAttrs[k]))
+						testCombo(color.New(backgroundAttrs[k], foregroundAttrs[j]))
+						testCombo(color.New(backgroundAttrs[k], baseAttrs[i]))
+						testCombo(color.New(baseAttrs[i], foregroundAttrs[j], backgroundAttrs[k]))
+					}
+				}
+			}
+		})
+
 	})
 }

--- a/internal/logging/posix.go
+++ b/internal/logging/posix.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package logging
+
+import (
+	"regexp"
+
+	"github.com/fatih/color"
+)
+
+var colorCodeMatcher = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func maybeStripColor(b []byte) string {
+	if color.NoColor {
+		return string(colorCodeMatcher.ReplaceAll(b, []byte("")))
+	}
+	return string(b)
+}

--- a/internal/logging/win.go
+++ b/internal/logging/win.go
@@ -1,0 +1,21 @@
+// +build windows
+
+package logging
+
+import (
+	"regexp"
+
+	"github.com/fatih/color"
+)
+
+func init() {
+	// the color library writes gobbledygook to the console on window so disable it
+	color.NoColor = true
+}
+
+var colorCodeMatcher = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// Remove all ANSI color information.
+func maybeStripColor(b []byte) string {
+	return string(colorCodeMatcher.ReplaceAll(b, []byte("")))
+}


### PR DESCRIPTION
Signed-off-by: John Murphy <johnmurphy@salesforce.com>

Closes #141 

Buildpack shell scripts produce output that contain control characters regardless of whether --no-color is enabled or not. This is because the docker API returns the raw output of the buildpack script which is then written to the terminal hosting pack.  If a user is on a Unix platform, this will produce colored output even though --no-color is true, and on Windows this produces garbled output because Windows consoles don't know how to interpret ANSI control characters pertaining to color. This change intercepts log output and scrubs it of color directives before it is written to the terminal.  On Unix the user may opt to have color or not, but on Windows color is always disabled because enabling it will produce garbled output.  