### PR TITLE
Improve stack/builders suggestions

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -831,7 +831,6 @@ func testAcceptance(t *testing.T, when spec.G, it spec.S, builder, runImageMirro
 			if err != nil {
 				t.Fatalf("suggest-stacks command failed: %s: %s", output, err)
 			}
-			h.AssertContains(t, string(output), "Stacks maintained by the Cloud Native Buildpacks project:")
 			h.AssertContains(t, string(output), "Stacks maintained by the community:")
 		})
 	})

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -133,14 +133,6 @@ func getBuilderDescription(builderName string, client PackClient) string {
 
 func suggestStacks(log logging.Logger) {
 	log.Info(`
-Stacks maintained by the Cloud Native Buildpacks project:
-
-    Stack ID: io.buildpacks.stacks.bionic
-    Description: Minimal Ubuntu 18.04 stack
-    Maintainer: Cloud Native Buildpacks
-    Build Image: cnbs/build:bionic
-    Run Image: cnbs/run:bionic
-
 Stacks maintained by the community:
 
     Stack ID: heroku-18
@@ -149,9 +141,21 @@ Stacks maintained by the community:
     Build Image: heroku/pack:18-build
     Run Image: heroku/pack:18
 
+    Stack ID: io.buildpacks.stacks.bionic
+    Description: A minimal Cloud Foundry stack based on Ubuntu 18.04
+    Maintainer: Cloud Foundry
+    Build Image: cloudfoundry/build:base-cnb
+    Run Image: cloudfoundry/run:base-cnb
+
     Stack ID: org.cloudfoundry.stacks.cflinuxfs3
-    Description: The official Cloud Foundry stack based on Ubuntu 18.04
+    Description: A large Cloud Foundry stack based on Ubuntu 18.04
     Maintainer: Cloud Foundry
     Build Image: cloudfoundry/build:full-cnb
-    Run Image: cloudfoundry/run:full-cnb`)
+    Run Image: cloudfoundry/run:full-cnb
+
+    Stack ID: org.cloudfoundry.stacks.tiny
+    Description: A tiny Cloud Foundry stack based on Ubuntu 18.04, similar to distroless
+    Maintainer: Cloud Foundry
+    Build Image: cloudfoundry/build:tiny-cnb
+    Run Image: cloudfoundry/run:tiny-cnb`)
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 	"text/tabwriter"
+	"text/template"
 
 	"github.com/spf13/cobra"
 
@@ -37,6 +38,45 @@ var suggestedBuilders = [][]suggestedBuilder{
 	},
 	{
 		{"Heroku", "heroku/buildpacks:18"},
+	},
+}
+
+type suggestedStack struct {
+	ID          string
+	Description string
+	Maintainer  string
+	BuildImage  string
+	RunImage    string
+}
+
+var suggestedStacks = []suggestedStack{
+	{
+		ID:          "heroku-18",
+		Description: "The official Heroku stack based on Ubuntu 18.04",
+		Maintainer:  "Heroku",
+		BuildImage:  "heroku/pack:18-build",
+		RunImage:    "heroku/pack:18",
+	},
+	{
+		ID:          "io.buildpacks.stacks.bionic",
+		Description: "A minimal Cloud Foundry stack based on Ubuntu 18.04",
+		Maintainer:  "Cloud Foundry",
+		BuildImage:  "cloudfoundry/build:base-cnb",
+		RunImage:    "cloudfoundry/run:base-cnb",
+	},
+	{
+		ID:          "org.cloudfoundry.stacks.cflinuxfs3",
+		Description: "A large Cloud Foundry stack based on Ubuntu 18.04",
+		Maintainer:  "Cloud Foundry",
+		BuildImage:  "cloudfoundry/build:full-cnb",
+		RunImage:    "cloudfoundry/run:full-cnb",
+	},
+	{
+		ID:          "org.cloudfoundry.stacks.tiny",
+		Description: "A tiny Cloud Foundry stack based on Ubuntu 18.04, similar to distroless",
+		Maintainer:  "Cloud Foundry",
+		BuildImage:  "cloudfoundry/build:tiny-cnb",
+		RunImage:    "cloudfoundry/run:tiny-cnb",
 	},
 }
 
@@ -132,30 +172,16 @@ func getBuilderDescription(builderName string, client PackClient) string {
 }
 
 func suggestStacks(log logging.Logger) {
-	log.Info(`
+	tmpl := template.Must(template.New("").Parse(`
 Stacks maintained by the community:
+{{- range . }}
 
-    Stack ID: heroku-18
-    Description: The official Heroku stack based on Ubuntu 18.04
-    Maintainer: Heroku
-    Build Image: heroku/pack:18-build
-    Run Image: heroku/pack:18
-
-    Stack ID: io.buildpacks.stacks.bionic
-    Description: A minimal Cloud Foundry stack based on Ubuntu 18.04
-    Maintainer: Cloud Foundry
-    Build Image: cloudfoundry/build:base-cnb
-    Run Image: cloudfoundry/run:base-cnb
-
-    Stack ID: org.cloudfoundry.stacks.cflinuxfs3
-    Description: A large Cloud Foundry stack based on Ubuntu 18.04
-    Maintainer: Cloud Foundry
-    Build Image: cloudfoundry/build:full-cnb
-    Run Image: cloudfoundry/run:full-cnb
-
-    Stack ID: org.cloudfoundry.stacks.tiny
-    Description: A tiny Cloud Foundry stack based on Ubuntu 18.04, similar to distroless
-    Maintainer: Cloud Foundry
-    Build Image: cloudfoundry/build:tiny-cnb
-    Run Image: cloudfoundry/run:tiny-cnb`)
+    Stack ID: {{ .ID }}
+    Description: {{ .Description }}
+    Maintainer: {{ .Maintainer }}
+    Build Image: {{ .BuildImage }}
+    Run Image: {{ .RunImage }}
+{{- end }}
+`))
+	tmpl.Execute(log.Writer(), suggestedStacks)
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -6,15 +6,12 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"text/tabwriter"
-	"text/template"
 
 	"github.com/spf13/cobra"
 
 	"github.com/buildpack/pack"
 	"github.com/buildpack/pack/config"
 	"github.com/buildpack/pack/logging"
-	"github.com/buildpack/pack/style"
 )
 
 //go:generate mockgen -package mocks -destination mocks/pack_client.go github.com/buildpack/pack/commands PackClient
@@ -23,69 +20,6 @@ type PackClient interface {
 	Rebase(context.Context, pack.RebaseOptions) error
 	CreateBuilder(context.Context, pack.CreateBuilderOptions) error
 	Build(context.Context, pack.BuildOptions) error
-}
-
-type suggestedBuilder struct {
-	Name               string
-	Image              string
-	DefaultDescription string
-}
-
-var suggestedBuilders = []suggestedBuilder{
-	{
-		Name:               "Cloud Foundry",
-		Image:              "cloudfoundry/cnb:bionic",
-		DefaultDescription: "Small base image with Java & Node.js",
-	},
-	{
-		Name:               "Cloud Foundry",
-		Image:              "cloudfoundry/cnb:cflinuxfs3",
-		DefaultDescription: "Larger base image with Java, Node.js & Python",
-	},
-	{
-		Name:               "Heroku",
-		Image:              "heroku/buildpacks:18",
-		DefaultDescription: "heroku-18 base image with buildpacks for Ruby, Java, Node.js, Python, Golang, & PHP",
-	},
-}
-
-type suggestedStack struct {
-	ID          string
-	Description string
-	Maintainer  string
-	BuildImage  string
-	RunImage    string
-}
-
-var suggestedStacks = []suggestedStack{
-	{
-		ID:          "heroku-18",
-		Description: "The official Heroku stack based on Ubuntu 18.04",
-		Maintainer:  "Heroku",
-		BuildImage:  "heroku/pack:18-build",
-		RunImage:    "heroku/pack:18",
-	},
-	{
-		ID:          "io.buildpacks.stacks.bionic",
-		Description: "A minimal Cloud Foundry stack based on Ubuntu 18.04",
-		Maintainer:  "Cloud Foundry",
-		BuildImage:  "cloudfoundry/build:base-cnb",
-		RunImage:    "cloudfoundry/run:base-cnb",
-	},
-	{
-		ID:          "org.cloudfoundry.stacks.cflinuxfs3",
-		Description: "A large Cloud Foundry stack based on Ubuntu 18.04",
-		Maintainer:  "Cloud Foundry",
-		BuildImage:  "cloudfoundry/build:full-cnb",
-		RunImage:    "cloudfoundry/run:full-cnb",
-	},
-	{
-		ID:          "org.cloudfoundry.stacks.tiny",
-		Description: "A tiny Cloud Foundry stack based on Ubuntu 18.04, similar to distroless",
-		Maintainer:  "Cloud Foundry",
-		BuildImage:  "cloudfoundry/build:tiny-cnb",
-		RunImage:    "cloudfoundry/run:tiny-cnb",
-	},
 }
 
 func AddHelpFlag(cmd *cobra.Command, commandName string) {
@@ -130,48 +64,4 @@ func getMirrors(config config.Config) map[string][]string {
 		mirrors[ri.Image] = ri.Mirrors
 	}
 	return mirrors
-}
-
-func suggestSettingBuilder(logger logging.Logger, client PackClient) {
-	logger.Info("Please select a default builder with:")
-	logger.Info("")
-	logger.Info("\tpack set-default-builder <builder image>")
-	logger.Info("")
-	suggestBuilders(logger, client)
-}
-
-func suggestBuilders(logger logging.Logger, client PackClient) {
-	logger.Info("Suggested builders:")
-	tw := tabwriter.NewWriter(logger.Writer(), 10, 10, 5, ' ', tabwriter.TabIndent)
-	for _, builder := range suggestedBuilders {
-		fmt.Fprintf(tw, "\t%s:\t%s\t%s\t\n", builder.Name, style.Symbol(builder.Image), getBuilderDescription(builder, client))
-	}
-	fmt.Fprintln(tw)
-
-	logging.Tip(logger, "Learn more about a specific builder with:\n")
-	logger.Info("\tpack inspect-builder [builder image]")
-}
-
-func getBuilderDescription(builder suggestedBuilder, client PackClient) string {
-	info, err := client.InspectBuilder(builder.Image, false)
-	if err == nil && info.Description != "" {
-		return info.Description
-	}
-
-	return builder.DefaultDescription
-}
-
-func suggestStacks(log logging.Logger) {
-	tmpl := template.Must(template.New("").Parse(`
-Stacks maintained by the community:
-{{- range . }}
-
-    Stack ID: {{ .ID }}
-    Description: {{ .Description }}
-    Maintainer: {{ .Maintainer }}
-    Build Image: {{ .BuildImage }}
-    Run Image: {{ .RunImage }}
-{{- end }}
-`))
-	tmpl.Execute(log.Writer(), suggestedStacks)
 }

--- a/commands/suggest_builders.go
+++ b/commands/suggest_builders.go
@@ -39,10 +39,9 @@ func SuggestBuilders(logger logging.Logger, client PackClient) *cobra.Command {
 		Use:   "suggest-builders",
 		Short: "Display list of recommended builders",
 		Args:  cobra.NoArgs,
-		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+		Run: func(*cobra.Command, []string) {
 			suggestBuilders(logger, client)
-			return nil
-		}),
+		},
 	}
 
 	AddHelpFlag(cmd, "suggest-builders")

--- a/commands/suggest_builders.go
+++ b/commands/suggest_builders.go
@@ -1,10 +1,38 @@
 package commands
 
 import (
+	"fmt"
+	"text/tabwriter"
+
 	"github.com/spf13/cobra"
 
 	"github.com/buildpack/pack/logging"
+	"github.com/buildpack/pack/style"
 )
+
+type suggestedBuilder struct {
+	Name               string
+	Image              string
+	DefaultDescription string
+}
+
+var suggestedBuilders = []suggestedBuilder{
+	{
+		Name:               "Cloud Foundry",
+		Image:              "cloudfoundry/cnb:bionic",
+		DefaultDescription: "Small base image with Java & Node.js",
+	},
+	{
+		Name:               "Cloud Foundry",
+		Image:              "cloudfoundry/cnb:cflinuxfs3",
+		DefaultDescription: "Larger base image with Java, Node.js & Python",
+	},
+	{
+		Name:               "Heroku",
+		Image:              "heroku/buildpacks:18",
+		DefaultDescription: "heroku-18 base image with buildpacks for Ruby, Java, Node.js, Python, Golang, & PHP",
+	},
+}
 
 func SuggestBuilders(logger logging.Logger, client PackClient) *cobra.Command {
 	cmd := &cobra.Command{
@@ -19,4 +47,33 @@ func SuggestBuilders(logger logging.Logger, client PackClient) *cobra.Command {
 
 	AddHelpFlag(cmd, "suggest-builders")
 	return cmd
+}
+
+func suggestSettingBuilder(logger logging.Logger, client PackClient) {
+	logger.Info("Please select a default builder with:")
+	logger.Info("")
+	logger.Info("\tpack set-default-builder <builder image>")
+	logger.Info("")
+	suggestBuilders(logger, client)
+}
+
+func suggestBuilders(logger logging.Logger, client PackClient) {
+	logger.Info("Suggested builders:")
+	tw := tabwriter.NewWriter(logger.Writer(), 10, 10, 5, ' ', tabwriter.TabIndent)
+	for _, builder := range suggestedBuilders {
+		fmt.Fprintf(tw, "\t%s:\t%s\t%s\t\n", builder.Name, style.Symbol(builder.Image), getBuilderDescription(builder, client))
+	}
+	fmt.Fprintln(tw)
+
+	logging.Tip(logger, "Learn more about a specific builder with:\n")
+	logger.Info("\tpack inspect-builder [builder image]")
+}
+
+func getBuilderDescription(builder suggestedBuilder, client PackClient) string {
+	info, err := client.InspectBuilder(builder.Image, false)
+	if err == nil && info.Description != "" {
+		return info.Description
+	}
+
+	return builder.DefaultDescription
 }

--- a/commands/suggest_builders.go
+++ b/commands/suggest_builders.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 	"text/tabwriter"
 
@@ -58,6 +59,8 @@ func suggestSettingBuilder(logger logging.Logger, client PackClient) {
 }
 
 func suggestBuilders(logger logging.Logger, client PackClient) {
+	sort.Slice(suggestedBuilders, func(i, j int) bool { return suggestedBuilders[i].Image < suggestedBuilders[j].Image })
+
 	logger.Info("Suggested builders:")
 
 	// Fetch descriptions concurrently.

--- a/commands/suggest_stacks.go
+++ b/commands/suggest_stacks.go
@@ -1,10 +1,51 @@
 package commands
 
 import (
+	"html/template"
+
 	"github.com/spf13/cobra"
 
 	"github.com/buildpack/pack/logging"
 )
+
+type suggestedStack struct {
+	ID          string
+	Description string
+	Maintainer  string
+	BuildImage  string
+	RunImage    string
+}
+
+var suggestedStacks = []suggestedStack{
+	{
+		ID:          "heroku-18",
+		Description: "The official Heroku stack based on Ubuntu 18.04",
+		Maintainer:  "Heroku",
+		BuildImage:  "heroku/pack:18-build",
+		RunImage:    "heroku/pack:18",
+	},
+	{
+		ID:          "io.buildpacks.stacks.bionic",
+		Description: "A minimal Cloud Foundry stack based on Ubuntu 18.04",
+		Maintainer:  "Cloud Foundry",
+		BuildImage:  "cloudfoundry/build:base-cnb",
+		RunImage:    "cloudfoundry/run:base-cnb",
+	},
+	{
+		ID:          "org.cloudfoundry.stacks.cflinuxfs3",
+		Description: "A large Cloud Foundry stack based on Ubuntu 18.04",
+		Maintainer:  "Cloud Foundry",
+		BuildImage:  "cloudfoundry/build:full-cnb",
+		RunImage:    "cloudfoundry/run:full-cnb",
+	},
+	{
+		ID:          "org.cloudfoundry.stacks.tiny",
+		Description: "A tiny Cloud Foundry stack based on Ubuntu 18.04, similar to distroless",
+		Maintainer:  "Cloud Foundry",
+		BuildImage:  "cloudfoundry/build:tiny-cnb",
+		RunImage:    "cloudfoundry/run:tiny-cnb",
+	},
+}
 
 func SuggestStacks(logger logging.Logger) *cobra.Command {
 	cmd := &cobra.Command{
@@ -19,4 +60,19 @@ func SuggestStacks(logger logging.Logger) *cobra.Command {
 
 	AddHelpFlag(cmd, "suggest-stacks")
 	return cmd
+}
+
+func suggestStacks(log logging.Logger) {
+	tmpl := template.Must(template.New("").Parse(`
+Stacks maintained by the community:
+{{- range . }}
+
+    Stack ID: {{ .ID }}
+    Description: {{ .Description }}
+    Maintainer: {{ .Maintainer }}
+    Build Image: {{ .BuildImage }}
+    Run Image: {{ .RunImage }}
+{{- end }}
+`))
+	tmpl.Execute(log.Writer(), suggestedStacks)
 }

--- a/commands/suggest_stacks.go
+++ b/commands/suggest_stacks.go
@@ -52,10 +52,9 @@ func SuggestStacks(logger logging.Logger) *cobra.Command {
 		Use:   "suggest-stacks",
 		Short: "Display list of recommended stacks",
 		Args:  cobra.NoArgs,
-		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+		Run: func(*cobra.Command, []string) {
 			suggestStacks(logger)
-			return nil
-		}),
+		},
 	}
 
 	AddHelpFlag(cmd, "suggest-stacks")

--- a/commands/suggest_stacks.go
+++ b/commands/suggest_stacks.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"html/template"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -62,6 +63,8 @@ func SuggestStacks(logger logging.Logger) *cobra.Command {
 }
 
 func suggestStacks(log logging.Logger) {
+	sort.Slice(suggestedStacks, func(i, j int) bool { return suggestedStacks[i].ID < suggestedStacks[j].ID })
+
 	tmpl := template.Must(template.New("").Parse(`
 Stacks maintained by the community:
 {{- range . }}

--- a/commands/suggest_stacks_test.go
+++ b/commands/suggest_stacks_test.go
@@ -32,14 +32,6 @@ func testSuggestStacksCommand(t *testing.T, when spec.G, it spec.S) {
 			command.SetArgs([]string{})
 			h.AssertNil(t, command.Execute())
 			h.AssertEq(t, outBuf.String(), `
-Stacks maintained by the Cloud Native Buildpacks project:
-
-    Stack ID: io.buildpacks.stacks.bionic
-    Description: Minimal Ubuntu 18.04 stack
-    Maintainer: Cloud Native Buildpacks
-    Build Image: cnbs/build:bionic
-    Run Image: cnbs/run:bionic
-
 Stacks maintained by the community:
 
     Stack ID: heroku-18
@@ -48,11 +40,23 @@ Stacks maintained by the community:
     Build Image: heroku/pack:18-build
     Run Image: heroku/pack:18
 
+    Stack ID: io.buildpacks.stacks.bionic
+    Description: A minimal Cloud Foundry stack based on Ubuntu 18.04
+    Maintainer: Cloud Foundry
+    Build Image: cloudfoundry/build:base-cnb
+    Run Image: cloudfoundry/run:base-cnb
+
     Stack ID: org.cloudfoundry.stacks.cflinuxfs3
-    Description: The official Cloud Foundry stack based on Ubuntu 18.04
+    Description: A large Cloud Foundry stack based on Ubuntu 18.04
     Maintainer: Cloud Foundry
     Build Image: cloudfoundry/build:full-cnb
     Run Image: cloudfoundry/run:full-cnb
+
+    Stack ID: org.cloudfoundry.stacks.tiny
+    Description: A tiny Cloud Foundry stack based on Ubuntu 18.04, similar to distroless
+    Maintainer: Cloud Foundry
+    Build Image: cloudfoundry/build:tiny-cnb
+    Run Image: cloudfoundry/run:tiny-cnb
 `)
 		})
 	})


### PR DESCRIPTION
 + Order stack/builders suggestions alphabetically
 + Move every stack under the `Stacks maintained by the community` category
 + Move code portions next to where they are used
 + Retrieve the builder descriptions concurrently
 + Simplify the code as much as I could

Fixes #311 and #329