### PR TITLE
Fix issue with builder reproducibility

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -484,29 +484,29 @@ func (b *Builder) defaultDirsLayer(dest string) (string, error) {
 	tw := tar.NewWriter(fh)
 	defer tw.Close()
 
-	now := time.Now()
+	ts := archive.NormalizedDateTime
 
-	if err := tw.WriteHeader(b.packOwnedDir(workspaceDir, now)); err != nil {
+	if err := tw.WriteHeader(b.packOwnedDir(workspaceDir, ts)); err != nil {
 		return "", errors.Wrapf(err, "creating %s dir in layer", style.Symbol(workspaceDir))
 	}
 
-	if err := tw.WriteHeader(b.packOwnedDir(layersDir, now)); err != nil {
+	if err := tw.WriteHeader(b.packOwnedDir(layersDir, ts)); err != nil {
 		return "", errors.Wrapf(err, "creating %s dir in layer", style.Symbol(layersDir))
 	}
 
-	if err := tw.WriteHeader(b.rootOwnedDir(cnbDir, now)); err != nil {
+	if err := tw.WriteHeader(b.rootOwnedDir(cnbDir, ts)); err != nil {
 		return "", errors.Wrapf(err, "creating %s dir in layer", style.Symbol(cnbDir))
 	}
 
-	if err := tw.WriteHeader(b.rootOwnedDir(dist.BuildpacksDir, now)); err != nil {
+	if err := tw.WriteHeader(b.rootOwnedDir(dist.BuildpacksDir, ts)); err != nil {
 		return "", errors.Wrapf(err, "creating %s dir in layer", style.Symbol(dist.BuildpacksDir))
 	}
 
-	if err := tw.WriteHeader(b.rootOwnedDir(platformDir, now)); err != nil {
+	if err := tw.WriteHeader(b.rootOwnedDir(platformDir, ts)); err != nil {
 		return "", errors.Wrapf(err, "creating %s dir in layer", style.Symbol(platformDir))
 	}
 
-	if err := tw.WriteHeader(b.rootOwnedDir(platformDir+"/env", now)); err != nil {
+	if err := tw.WriteHeader(b.rootOwnedDir(platformDir+"/env", ts)); err != nil {
 		return "", errors.Wrapf(err, "creating %s dir in layer", style.Symbol(platformDir+"/env"))
 	}
 
@@ -627,14 +627,12 @@ func (b *Builder) envLayer(dest string, env map[string]string) (string, error) {
 	tw := tar.NewWriter(fh)
 	defer tw.Close()
 
-	now := time.Now()
-
 	for k, v := range env {
 		if err := tw.WriteHeader(&tar.Header{
 			Name:    path.Join(platformDir, "env", k),
 			Size:    int64(len(v)),
 			Mode:    0644,
-			ModTime: now,
+			ModTime: archive.NormalizedDateTime,
 		}); err != nil {
 			return "", err
 		}
@@ -656,13 +654,11 @@ func (b *Builder) lifecycleLayer(dest string) (string, error) {
 	tw := tar.NewWriter(fh)
 	defer tw.Close()
 
-	now := time.Now()
-
 	if err := tw.WriteHeader(&tar.Header{
 		Typeflag: tar.TypeDir,
 		Name:     lifecycleDir,
 		Mode:     0755,
-		ModTime:  now,
+		ModTime:  archive.NormalizedDateTime,
 	}); err != nil {
 		return "", err
 	}

--- a/builder/compat.go
+++ b/builder/compat.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
@@ -56,15 +55,15 @@ func compatLifecycle(tw *tar.Writer) error {
 }
 
 func (b *Builder) compatBuildpacks(tw *tar.Writer) error {
-	now := time.Now()
-	if err := tw.WriteHeader(b.rootOwnedDir(compatBuildpacksDir, now)); err != nil {
+	ts := archive.NormalizedDateTime
+	if err := tw.WriteHeader(b.rootOwnedDir(compatBuildpacksDir, ts)); err != nil {
 		return errors.Wrapf(err, "creating %s dir in layer", style.Symbol(dist.BuildpacksDir))
 	}
 	for _, bp := range b.additionalBuildpacks {
 		descriptor := bp.Descriptor()
 
 		compatDir := path.Join(compatBuildpacksDir, descriptor.EscapedID())
-		if err := tw.WriteHeader(b.rootOwnedDir(compatDir, now)); err != nil {
+		if err := tw.WriteHeader(b.rootOwnedDir(compatDir, ts)); err != nil {
 			return errors.Wrapf(err, "creating %s dir in layer", style.Symbol(compatDir))
 		}
 		compatLink := path.Join(compatDir, descriptor.Info.Version)
@@ -97,6 +96,7 @@ func addSymlink(tw *tar.Writer, name, linkName string) error {
 		Linkname: linkName,
 		Typeflag: tar.TypeSymlink,
 		Mode:     0644,
+		ModTime:  archive.NormalizedDateTime,
 	}); err != nil {
 		return errors.Wrapf(err, "creating %s symlink", style.Symbol(name))
 	}

--- a/builder/compat_test.go
+++ b/builder/compat_test.go
@@ -142,15 +142,25 @@ func testCompat(t *testing.T, when spec.G, it spec.S) {
 			layerTar, err = baseImage.FindLayerWithPath("/buildpacks/buildpack-1-id/buildpack-1-version-1")
 			h.AssertNil(t, err)
 
+			h.AssertOnTarEntry(t, layerTar, "/buildpacks/buildpack-1-id",
+				h.HasModTime(archive.NormalizedDateTime),
+			)
+
 			h.AssertOnTarEntry(t, layerTar, "/buildpacks/buildpack-1-id/buildpack-1-version-1",
 				h.SymlinksTo("/cnb/buildpacks/buildpack-1-id/buildpack-1-version-1"),
+				h.HasModTime(archive.NormalizedDateTime),
 			)
 
 			layerTar, err = baseImage.FindLayerWithPath("/buildpacks/buildpack-2-id/buildpack-2-version-1")
 			h.AssertNil(t, err)
 
+			h.AssertOnTarEntry(t, layerTar, "/buildpacks/buildpack-2-id",
+				h.HasModTime(archive.NormalizedDateTime),
+			)
+
 			h.AssertOnTarEntry(t, layerTar, "/buildpacks/buildpack-2-id/buildpack-2-version-1",
 				h.SymlinksTo("/cnb/buildpacks/buildpack-2-id/buildpack-2-version-1"),
+				h.HasModTime(archive.NormalizedDateTime),
 			)
 		})
 
@@ -176,6 +186,7 @@ func testCompat(t *testing.T, when spec.G, it spec.S) {
 				h.IsDirectory(),
 				h.HasOwnerAndGroup(0, 0),
 				h.HasFileMode(0755),
+				h.HasModTime(archive.NormalizedDateTime),
 			)
 		})
 
@@ -192,10 +203,13 @@ func testCompat(t *testing.T, when spec.G, it spec.S) {
 			it("adds a compat stack.toml to the image", func() {
 				layerTar, err := baseImage.FindLayerWithPath("/buildpacks/stack.toml")
 				h.AssertNil(t, err)
-				h.AssertOnTarEntry(t, layerTar, "/buildpacks/stack.toml", h.ContentEquals(`[run-image]
+				h.AssertOnTarEntry(t, layerTar, "/buildpacks/stack.toml",
+					h.ContentEquals(`[run-image]
   image = "some/run"
   mirrors = ["some/mirror", "other/mirror"]
-`))
+`),
+					h.HasModTime(archive.NormalizedDateTime),
+				)
 			})
 		})
 
@@ -308,7 +322,10 @@ func testCompat(t *testing.T, when spec.G, it spec.S) {
 
 			layerTar, err := baseImage.FindLayerWithPath("/lifecycle")
 			h.AssertNil(t, err)
-			h.AssertOnTarEntry(t, layerTar, "/lifecycle", h.SymlinksTo("/cnb/lifecycle"))
+			h.AssertOnTarEntry(t, layerTar, "/lifecycle",
+				h.SymlinksTo("/cnb/lifecycle"),
+				h.HasModTime(archive.NormalizedDateTime),
+			)
 		})
 	})
 }

--- a/dist/layers.go
+++ b/dist/layers.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"time"
 
 	"github.com/pkg/errors"
+
+	"github.com/buildpack/pack/internal/archive"
 )
 
 const BuildpacksDir = "/cnb/buildpacks"
@@ -33,13 +34,13 @@ func BuildpackLayer(dest string, uid, gid int, bp Buildpack) (string, error) {
 	tw := tar.NewWriter(fh)
 	defer tw.Close()
 
-	now := time.Now()
+	ts := archive.NormalizedDateTime
 
 	if err := tw.WriteHeader(&tar.Header{
 		Typeflag: tar.TypeDir,
 		Name:     path.Join(BuildpacksDir, bpd.EscapedID()),
 		Mode:     0755,
-		ModTime:  now,
+		ModTime:  ts,
 	}); err != nil {
 		return "", err
 	}
@@ -49,7 +50,7 @@ func BuildpackLayer(dest string, uid, gid int, bp Buildpack) (string, error) {
 		Typeflag: tar.TypeDir,
 		Name:     baseTarDir,
 		Mode:     0755,
-		ModTime:  now,
+		ModTime:  ts,
 	}); err != nil {
 		return "", err
 	}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -85,7 +85,7 @@ func aggregateError(base, addition error) error {
 func CreateSingleFileTarReader(path, txt string) (io.Reader, error) {
 	var buf bytes.Buffer
 	tarBuilder := TarBuilder{}
-	tarBuilder.AddFile(path, 0644, []byte(txt))
+	tarBuilder.AddFile(path, 0644, NormalizedDateTime, []byte(txt))
 	_, err := tarBuilder.WriteTo(&buf)
 	if err != nil {
 		return nil, err
@@ -96,15 +96,16 @@ func CreateSingleFileTarReader(path, txt string) (io.Reader, error) {
 
 func CreateSingleFileTar(tarFile, path, txt string) error {
 	tarBuilder := TarBuilder{}
-	tarBuilder.AddFile(path, 0644, []byte(txt))
+	tarBuilder.AddFile(path, 0644, NormalizedDateTime, []byte(txt))
 	return tarBuilder.WriteToPath(tarFile)
 }
 
 func AddFileToTar(tw *tar.Writer, path string, txt string) error {
 	if err := tw.WriteHeader(&tar.Header{
-		Name: path,
-		Size: int64(len(txt)),
-		Mode: 0644,
+		Name:    path,
+		Size:    int64(len(txt)),
+		Mode:    0644,
+		ModTime: NormalizedDateTime,
 	}); err != nil {
 		return err
 	}

--- a/internal/archive/tar_builder.go
+++ b/internal/archive/tar_builder.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"io"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -18,23 +19,26 @@ type fileEntry struct {
 	typeFlag byte
 	path     string
 	mode     int64
+	modTime  time.Time
 	contents []byte
 }
 
-func (t *TarBuilder) AddFile(path string, mode int64, contents []byte) {
+func (t *TarBuilder) AddFile(path string, mode int64, modTime time.Time, contents []byte) {
 	t.files = append(t.files, fileEntry{
 		typeFlag: tar.TypeReg,
 		path:     path,
 		mode:     mode,
+		modTime:  modTime,
 		contents: contents,
 	})
 }
 
-func (t *TarBuilder) AddDir(path string, mode int64) {
+func (t *TarBuilder) AddDir(path string, mode int64, modTime time.Time) {
 	t.files = append(t.files, fileEntry{
 		typeFlag: tar.TypeDir,
 		path:     path,
 		mode:     mode,
+		modTime:  modTime,
 	})
 }
 
@@ -73,6 +77,7 @@ func (t *TarBuilder) WriteTo(writer io.Writer) (int64, error) {
 			Name:     f.path,
 			Size:     int64(len(f.contents)),
 			Mode:     f.mode,
+			ModTime:  f.modTime,
 		}); err != nil {
 			return written, err
 		}

--- a/internal/fakes/fake_buildpack_blob.go
+++ b/internal/fakes/fake_buildpack_blob.go
@@ -3,6 +3,7 @@ package fakes
 import (
 	"bytes"
 	"io"
+	"time"
 
 	"github.com/BurntSushi/toml"
 
@@ -42,10 +43,10 @@ func (b *fakeBuildpackBlob) Open() (reader io.ReadCloser, err error) {
 	}
 
 	tarBuilder := archive.TarBuilder{}
-	tarBuilder.AddFile("buildpack.toml", b.chmod, buf.Bytes())
-	tarBuilder.AddDir("bin", b.chmod)
-	tarBuilder.AddFile("bin/build", b.chmod, []byte("build-contents"))
-	tarBuilder.AddFile("bin/detect", b.chmod, []byte("detect-contents"))
+	tarBuilder.AddFile("buildpack.toml", b.chmod, time.Now(), buf.Bytes())
+	tarBuilder.AddDir("bin", b.chmod, time.Now())
+	tarBuilder.AddFile("bin/build", b.chmod, time.Now(), []byte("build-contents"))
+	tarBuilder.AddFile("bin/detect", b.chmod, time.Now(), []byte("detect-contents"))
 
 	return tarBuilder.Reader(), err
 }

--- a/testhelpers/tar_assertions.go
+++ b/testhelpers/tar_assertions.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -91,6 +92,15 @@ func HasFileMode(expectedMode int64) TarEntryAssertion {
 		t.Helper()
 		if header.Mode != expectedMode {
 			t.Fatalf("expected '%s' to have mode '%o', but got '%o'", header.Name, expectedMode, header.Mode)
+		}
+	}
+}
+
+func HasModTime(expectedTime time.Time) TarEntryAssertion {
+	return func(t *testing.T, header *tar.Header, _ []byte) {
+		t.Helper()
+		if header.ModTime.UnixNano() != expectedTime.UnixNano() {
+			t.Fatalf("expected '%s' to have mod time '%s', but got '%s'", header.Name, expectedTime, header.ModTime)
 		}
 	}
 }


### PR DESCRIPTION
Use consistent timestamps to avoid unnecessary layer changes

Signed-off-by: Andrew Meyer <ameyer@pivotal.io>
Signed-off-by: Javier Romero <jromero@pivotal.io>