### PR TITLE
Hide create-package command

### DIFF
--- a/commands/create_package.go
+++ b/commands/create_package.go
@@ -52,6 +52,9 @@ func CreatePackage(logger logging.Logger, client PackClient) *cobra.Command {
 	cmd.MarkFlagRequired("package-config")
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, "Publish to registry")
 	AddHelpFlag(cmd, "create-package")
+
+	cmd.Hidden = true
+
 	return cmd
 }
 


### PR DESCRIPTION
We are hiding this command as it's not ready for prime-time without additional follow up issues (#240, #347, #348, #349) yet some early adopters might want to play with it.

Signed-off-by: Andrew Meyer <ameyer@pivotal.io>