### PR TITLE
Make download URL and progress output consistent

### DIFF
--- a/blob/downloader.go
+++ b/blob/downloader.go
@@ -140,8 +140,8 @@ func (d *downloader) downloadAsStream(ctx context.Context, uri string, etag stri
 	}
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		d.logger.Debugf("Downloading from %s", style.Symbol(uri))
-		return withProgress(resp.Body, resp.ContentLength), resp.Header.Get("Etag"), nil
+		d.logger.Infof("Downloading from %s", style.Symbol(uri))
+		return withProgress(logging.GetInfoWriter(d.logger), resp.Body, resp.ContentLength), resp.Header.Get("Etag"), nil
 	}
 
 	if resp.StatusCode == 304 {
@@ -155,13 +155,13 @@ func (d *downloader) downloadAsStream(ctx context.Context, uri string, etag stri
 	)
 }
 
-func withProgress(rc io.ReadCloser, length int64) io.ReadCloser {
+func withProgress(writer io.Writer, rc io.ReadCloser, length int64) io.ReadCloser {
 	return &progressReader{
 		Closer: rc,
 		Reader: &ioprogress.Reader{
 			Reader:   rc,
 			Size:     length,
-			DrawFunc: ioprogress.DrawTerminalf(os.Stdout, ioprogress.DrawTextFormatBytes),
+			DrawFunc: ioprogress.DrawTerminalf(writer, ioprogress.DrawTextFormatBytes),
 		},
 	}
 }

--- a/build.go
+++ b/build.go
@@ -258,8 +258,6 @@ func (c *Client) processBuildpacks(ctx context.Context, buildpacks []string) ([]
 				return nil, dist.OrderEntry{}, err
 			}
 
-			c.logger.Debugf("fetching buildpack from %s", style.Symbol(bp))
-
 			blob, err := c.downloader.Download(ctx, bp)
 			if err != nil {
 				return nil, dist.OrderEntry{}, errors.Wrapf(err, "downloading buildpack from %s", style.Symbol(bp))
@@ -343,11 +341,11 @@ func (c *Client) createEphemeralBuilder(rawBuilderImage imgutil.Image, env map[s
 	bldr.SetEnv(env)
 	for _, bp := range buildpacks {
 		bpInfo := bp.Descriptor().Info
-		c.logger.Debugf("adding buildpack %s version %s to builder", style.Symbol(bpInfo.ID), style.Symbol(bpInfo.Version))
+		c.logger.Debugf("Adding buildpack %s version %s to builder", style.Symbol(bpInfo.ID), style.Symbol(bpInfo.Version))
 		bldr.AddBuildpack(bp)
 	}
 	if len(group.Group) > 0 {
-		c.logger.Debug("setting custom order")
+		c.logger.Debug("Setting custom order")
 		bldr.SetOrder([]dist.OrderEntry{group})
 	}
 	if err := bldr.Save(c.logger); err != nil {


### PR DESCRIPTION
Always show download URL and progress

- Also tidied other output

Signed-off-by: Andrew Meyer <ameyer@pivotal.io>

Resolves #355 