### PR TITLE
Add report command

### DIFF
--- a/acceptance/testdata/pack_current/report_output.txt
+++ b/acceptance/testdata/pack_current/report_output.txt
@@ -1,0 +1,8 @@
+Pack:
+  Version:  {{ .Version }}
+  OS/Arch:  {{ .OS }}/{{ .Arch }}
+
+Default Lifecycle Version:  0.5.0
+
+Config:
+  default-builder-image = "{{ .DefaultBuilder }}"

--- a/cmd/pack/main.go
+++ b/cmd/pack/main.go
@@ -70,6 +70,7 @@ func main() {
 
 	rootCmd.AddCommand(commands.SuggestStacks(logger))
 	rootCmd.AddCommand(commands.Version(logger, cmd.Version))
+	rootCmd.AddCommand(commands.Report(logger))
 
 	rootCmd.AddCommand(commands.CompletionCommand(logger))
 

--- a/commands/report.go
+++ b/commands/report.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"runtime"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+
+	"github.com/buildpack/pack/builder"
+	"github.com/buildpack/pack/cmd"
+	"github.com/buildpack/pack/config"
+	"github.com/buildpack/pack/logging"
+)
+
+func Report(logger logging.Logger) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "report",
+		Args:  cobra.NoArgs,
+		Short: "Display useful information for reporting an issue",
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			var buf bytes.Buffer
+			err := generateOutput(&buf)
+			if err != nil {
+				return err
+			}
+
+			logger.Info(buf.String())
+
+			return nil
+		}),
+	}
+	AddHelpFlag(cmd, "report")
+	return cmd
+}
+
+func generateOutput(writer io.Writer) error {
+	tpl := template.Must(template.New("").Parse(`Pack:
+  Version:  {{ .Version }}
+  OS/Arch:  {{ .OS }}/{{ .Arch }}
+
+Default Lifecycle Version:  {{ .DefaultLifecycleVersion }}
+
+Config:
+{{ .Config -}}`))
+
+	configData := ""
+	if path, err := config.DefaultConfigPath(); err != nil {
+		configData = fmt.Sprintf("(error: %s)", err.Error())
+	} else if data, err := ioutil.ReadFile(path); err != nil {
+		configData = fmt.Sprintf("(error: %s)", err.Error())
+	} else {
+		var padded strings.Builder
+		for _, line := range strings.Split(string(data), "\n") {
+			_, _ = fmt.Fprintf(&padded, "  %s\n", line)
+		}
+		configData = strings.TrimRight(padded.String(), " \n")
+	}
+
+	return tpl.Execute(writer, map[string]string{
+		"Version":                 cmd.Version,
+		"OS":                      runtime.GOOS,
+		"Arch":                    runtime.GOARCH,
+		"DefaultLifecycleVersion": builder.DefaultLifecycleVersion,
+		"Config":                  configData,
+	})
+}


### PR DESCRIPTION
Resolves #257 

Example output:
```
$ ./out/pack report
Pack:
  Version:  dev-2019-11-03-09:24:11
  OS/Arch:  darwin/amd64

Default Lifecycle Version:  0.5.0

Config:
  default-builder-image = "some/image"
```


Signed-off-by: Javier Romero <root@jromero.codes>