### PR TITLE
Validate mixins

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -118,7 +118,7 @@ func (l *Lifecycle) Setup(opts LifecycleOptions) {
 	l.httpProxy = opts.HTTPProxy
 	l.httpsProxy = opts.HTTPSProxy
 	l.noProxy = opts.NoProxy
-	l.version = opts.Builder.GetLifecycleDescriptor().Info.Version.String()
+	l.version = opts.Builder.LifecycleDescriptor().Info.Version.String()
 }
 
 func (l *Lifecycle) Cleanup() error {

--- a/build/phase_test.go
+++ b/build/phase_test.go
@@ -343,7 +343,7 @@ func CreateFakeLifecycle(appDir string, docker *client.Client, logger logging.Lo
 		return nil, err
 	}
 
-	bldr, err := builder.GetBuilder(builderImage)
+	bldr, err := builder.FromImage(builderImage)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/compat_test.go
+++ b/builder/compat_test.go
@@ -190,9 +190,9 @@ func testCompat(t *testing.T, when spec.G, it spec.S) {
 			)
 		})
 
-		when("#SetStackInfo", func() {
+		when("#SetStack", func() {
 			it.Before(func() {
-				subject.SetStackInfo(builder.StackConfig{
+				subject.SetStack(builder.StackConfig{
 					RunImage:        "some/run",
 					RunImageMirrors: []string{"some/mirror", "other/mirror"},
 				})

--- a/builder/metadata.go
+++ b/builder/metadata.go
@@ -2,14 +2,17 @@ package builder
 
 import "github.com/buildpack/pack/dist"
 
-const OrderLabel = "io.buildpacks.buildpack.order"
-const BuildpackLayersLabel = "io.buildpacks.buildpack.layers"
+const (
+	OrderLabel           = "io.buildpacks.buildpack.order"
+	BuildpackLayersLabel = "io.buildpacks.buildpack.layers"
+)
 
 type BuildpackLayers map[string]map[string]BuildpackLayerInfo
 
 type BuildpackLayerInfo struct {
-	LayerDiffID string     `json:"layerDiffID"`
-	Order       dist.Order `json:"order,omitempty"`
+	LayerDiffID string       `json:"layerDiffID"`
+	Order       dist.Order   `json:"order,omitempty"`
+	Stacks      []dist.Stack `json:"stacks,omitempty"`
 }
 
 type Metadata struct {

--- a/commands/inspect_builder_test.go
+++ b/commands/inspect_builder_test.go
@@ -58,7 +58,7 @@ func testInspectBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 		mockController.Finish()
 	})
 
-	when("#GetBuilder", func() {
+	when("#Get", func() {
 		when("image cannot be found", func() {
 			it("logs 'Not present'", func() {
 				mockClient.EXPECT().InspectBuilder("some/image", false).Return(nil, nil)

--- a/create_builder.go
+++ b/create_builder.go
@@ -36,18 +36,18 @@ func (c *Client) CreateBuilder(ctx context.Context, opts CreateBuilderOptions) e
 	}
 
 	c.logger.Debugf("Creating builder %s from build-image %s", style.Symbol(opts.BuilderName), style.Symbol(baseImage.Name()))
-	builderImage, err := builder.New(baseImage, opts.BuilderName)
+	bldr, err := builder.New(baseImage, opts.BuilderName)
 	if err != nil {
 		return errors.Wrap(err, "invalid build-image")
 	}
 
-	builderImage.SetDescription(opts.BuilderConfig.Description)
+	bldr.SetDescription(opts.BuilderConfig.Description)
 
-	if builderImage.StackID != opts.BuilderConfig.Stack.ID {
+	if bldr.StackID != opts.BuilderConfig.Stack.ID {
 		return fmt.Errorf(
 			"stack %s from builder config is incompatible with stack %s from build image",
 			style.Symbol(opts.BuilderConfig.Stack.ID),
-			style.Symbol(builderImage.StackID),
+			style.Symbol(bldr.StackID),
 		)
 	}
 
@@ -56,7 +56,7 @@ func (c *Client) CreateBuilder(ctx context.Context, opts CreateBuilderOptions) e
 		return errors.Wrap(err, "fetch lifecycle")
 	}
 
-	if err := builderImage.SetLifecycle(lifecycle); err != nil {
+	if err := bldr.SetLifecycle(lifecycle); err != nil {
 		return errors.Wrap(err, "setting lifecycle")
 	}
 
@@ -81,13 +81,13 @@ func (c *Client) CreateBuilder(ctx context.Context, opts CreateBuilderOptions) e
 			return errors.Wrap(err, "invalid buildpack")
 		}
 
-		builderImage.AddBuildpack(fetchedBp)
+		bldr.AddBuildpack(fetchedBp)
 	}
 
-	builderImage.SetOrder(opts.BuilderConfig.Order)
-	builderImage.SetStackInfo(opts.BuilderConfig.Stack)
+	bldr.SetOrder(opts.BuilderConfig.Order)
+	bldr.SetStack(opts.BuilderConfig.Stack)
 
-	return builderImage.Save(c.logger)
+	return bldr.Save(c.logger)
 }
 
 func validateBuildpack(bp dist.Buildpack, source, expectedID, expectedBPVersion string) error {

--- a/dist/buildpack_descriptor.go
+++ b/dist/buildpack_descriptor.go
@@ -1,0 +1,59 @@
+package dist
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/buildpack/pack/api"
+	"github.com/buildpack/pack/style"
+)
+
+type BuildpackDescriptor struct {
+	API    *api.Version  `toml:"api"`
+	Info   BuildpackInfo `toml:"buildpack"`
+	Stacks []Stack       `toml:"stacks"`
+	Order  Order         `toml:"order"`
+}
+
+func (b *BuildpackDescriptor) EscapedID() string {
+	return strings.Replace(b.Info.ID, "/", "_", -1)
+}
+
+func (b *BuildpackDescriptor) EnsureStackSupport(stackID string, providedMixins []string, validateRunOnlyMixins bool) error {
+	avail := map[string]interface{}{}
+	for _, m := range providedMixins {
+		avail[m] = nil
+	}
+
+	if len(b.Stacks) == 0 {
+		return nil // Order buildpack, no validation required
+	}
+
+	bpMixins, err := b.findMixinsForStack(stackID)
+	if err != nil {
+		return err
+	}
+
+	var missing []string
+	for _, m := range bpMixins {
+		ignored := !validateRunOnlyMixins && strings.HasPrefix(m, "run:")
+		if _, ok := avail[m]; !ignored && !ok {
+			missing = append(missing, m)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		return fmt.Errorf("buildpack %s requires missing mixin(s): %s", style.Symbol(b.Info.FullName()), strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func (b *BuildpackDescriptor) findMixinsForStack(stackID string) ([]string, error) {
+	for _, s := range b.Stacks {
+		if s.ID == stackID {
+			return s.Mixins, nil
+		}
+	}
+	return nil, fmt.Errorf("buildpack %s does not support stack %s", style.Symbol(b.Info.FullName()), style.Symbol(stackID))
+}

--- a/dist/buildpack_descriptor_test.go
+++ b/dist/buildpack_descriptor_test.go
@@ -1,0 +1,124 @@
+package dist
+
+import (
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	h "github.com/buildpack/pack/testhelpers"
+)
+
+func TestBuildpackDescriptor(t *testing.T) {
+	color.Disable(true)
+	defer func() { color.Disable(false) }()
+	spec.Run(t, "testBuildpackDescriptor", testBuildpackDescriptor, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testBuildpackDescriptor(t *testing.T, when spec.G, it spec.S) {
+	when("#EnsureStackSupport", func() {
+		when("not validating against run image mixins", func() {
+			it("ignores run-only mixins", func() {
+				bp := BuildpackDescriptor{
+					Info: BuildpackInfo{
+						ID:      "some.buildpack.id",
+						Version: "some.buildpack.version",
+					},
+					Stacks: []Stack{{
+						ID:     "some.stack.id",
+						Mixins: []string{"mixinA", "build:mixinB", "run:mixinD"},
+					}},
+				}
+
+				providedMixins := []string{"mixinA", "build:mixinB", "mixinC"}
+				h.AssertNil(t, bp.EnsureStackSupport("some.stack.id", providedMixins, false))
+			})
+
+			it("returns an error with any missing (and non-ignored) mixins", func() {
+				bp := BuildpackDescriptor{
+					Info: BuildpackInfo{
+						ID:      "some.buildpack.id",
+						Version: "some.buildpack.version",
+					},
+					Stacks: []Stack{{
+						ID:     "some.stack.id",
+						Mixins: []string{"mixinX", "mixinY", "run:mixinZ"},
+					}},
+				}
+
+				providedMixins := []string{"mixinA", "mixinB"}
+				err := bp.EnsureStackSupport("some.stack.id", providedMixins, false)
+
+				h.AssertError(t, err, "buildpack 'some.buildpack.id@some.buildpack.version' requires missing mixin(s): mixinX, mixinY")
+			})
+		})
+
+		when("validating against run image mixins", func() {
+			it("requires run-only mixins", func() {
+				bp := BuildpackDescriptor{
+					Info: BuildpackInfo{
+						ID:      "some.buildpack.id",
+						Version: "some.buildpack.version",
+					},
+					Stacks: []Stack{{
+						ID:     "some.stack.id",
+						Mixins: []string{"mixinA", "build:mixinB", "run:mixinD"},
+					}},
+				}
+
+				providedMixins := []string{"mixinA", "build:mixinB", "mixinC", "run:mixinD"}
+
+				h.AssertNil(t, bp.EnsureStackSupport("some.stack.id", providedMixins, true))
+			})
+
+			it("returns an error with any missing mixins", func() {
+				bp := BuildpackDescriptor{
+					Info: BuildpackInfo{
+						ID:      "some.buildpack.id",
+						Version: "some.buildpack.version",
+					},
+					Stacks: []Stack{{
+						ID:     "some.stack.id",
+						Mixins: []string{"mixinX", "mixinY", "run:mixinZ"},
+					}},
+				}
+
+				providedMixins := []string{"mixinA", "mixinB"}
+
+				err := bp.EnsureStackSupport("some.stack.id", providedMixins, true)
+
+				h.AssertError(t, err, "buildpack 'some.buildpack.id@some.buildpack.version' requires missing mixin(s): mixinX, mixinY, run:mixinZ")
+			})
+		})
+
+		it("returns an error when buildpack does not support stack", func() {
+			bp := BuildpackDescriptor{
+				Info: BuildpackInfo{
+					ID:      "some.buildpack.id",
+					Version: "some.buildpack.version",
+				},
+				Stacks: []Stack{{
+					ID:     "some.stack.id",
+					Mixins: []string{"mixinX", "mixinY"},
+				}},
+			}
+
+			err := bp.EnsureStackSupport("some.nonexistent.stack.id", []string{"mixinA"}, true)
+
+			h.AssertError(t, err, "buildpack 'some.buildpack.id@some.buildpack.version' does not support stack 'some.nonexistent.stack.id")
+		})
+
+		it("skips validating order buildpack", func() {
+			bp := BuildpackDescriptor{
+				Info: BuildpackInfo{
+					ID:      "some.buildpack.id",
+					Version: "some.buildpack.version",
+				},
+				Stacks: []Stack{},
+			}
+
+			h.AssertNil(t, bp.EnsureStackSupport("some.stack.id", []string{"mixinA"}, true))
+		})
+	})
+}

--- a/inspect_builder.go
+++ b/inspect_builder.go
@@ -36,7 +36,7 @@ func (c *Client) InspectBuilder(name string, daemon bool) (*BuilderInfo, error) 
 		return nil, err
 	}
 
-	bldr, err := builder.GetBuilder(img)
+	bldr, err := builder.FromImage(img)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid builder %s", style.Symbol(name))
 	}
@@ -44,11 +44,11 @@ func (c *Client) InspectBuilder(name string, daemon bool) (*BuilderInfo, error) 
 	return &BuilderInfo{
 		Description:     bldr.Description(),
 		Stack:           bldr.StackID,
-		RunImage:        bldr.GetStackInfo().RunImage.Image,
-		RunImageMirrors: bldr.GetStackInfo().RunImage.Mirrors,
-		Buildpacks:      bldr.GetBuildpacks(),
-		Order:           bldr.GetOrder(),
-		Lifecycle:       bldr.GetLifecycleDescriptor(),
-		CreatedBy:       bldr.GetCreatedBy(),
+		RunImage:        bldr.Stack().RunImage.Image,
+		RunImageMirrors: bldr.Stack().RunImage.Mirrors,
+		Buildpacks:      bldr.Buildpacks(),
+		Order:           bldr.Order(),
+		Lifecycle:       bldr.LifecycleDescriptor(),
+		CreatedBy:       bldr.CreatedBy(),
 	}, nil
 }

--- a/internal/fakes/fake_images.go
+++ b/internal/fakes/fake_images.go
@@ -10,13 +10,20 @@ import (
 	h "github.com/buildpack/pack/testhelpers"
 )
 
-func NewFakeBuilderImage(t *testing.T, name string, stackID, uid, gid string, metadata builder.Metadata) *fakes.Image {
+func NewFakeBuilderImage(t *testing.T, name string, stackID, uid, gid string, metadata builder.Metadata, bpLayers builder.BuildpackLayers) *fakes.Image {
 	fakeBuilderImage := fakes.NewImage(name, "", nil)
+
 	h.AssertNil(t, fakeBuilderImage.SetLabel("io.buildpacks.stack.id", stackID))
 	h.AssertNil(t, fakeBuilderImage.SetEnv("CNB_USER_ID", uid))
 	h.AssertNil(t, fakeBuilderImage.SetEnv("CNB_GROUP_ID", gid))
+
 	label, err := json.Marshal(&metadata)
 	h.AssertNil(t, err)
 	h.AssertNil(t, fakeBuilderImage.SetLabel("io.buildpacks.builder.metadata", string(label)))
+
+	label, err = json.Marshal(&bpLayers)
+	h.AssertNil(t, err)
+	h.AssertNil(t, fakeBuilderImage.SetLabel("io.buildpacks.buildpack.layers", string(label)))
+
 	return fakeBuilderImage
 }

--- a/stack/mixins.go
+++ b/stack/mixins.go
@@ -1,0 +1,71 @@
+package stack
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/buildpack/pack/style"
+)
+
+const MixinsLabel = "io.buildpacks.stack.mixins"
+
+func ValidateMixins(buildImageName string, buildImageMixins []string, runImageName string, runImageMixins []string) error {
+	bMixins, err := mixinSet(buildImageMixins, buildImageName, false)
+	if err != nil {
+		return err
+	}
+
+	rMixins, err := mixinSet(runImageMixins, runImageName, true)
+	if err != nil {
+		return err
+	}
+
+	if err := validateMissing(rMixins, bMixins, runImageName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func mixinSet(mixins []string, imageName string, run bool) (map[string]interface{}, error) {
+	set := map[string]interface{}{}
+	invalidPrefix := "run"
+	excludePrefix := "build"
+	if run {
+		invalidPrefix = "build"
+		excludePrefix = "run"
+	}
+
+	var invalid []string
+	for _, m := range mixins {
+		if strings.HasPrefix(m, invalidPrefix+":") {
+			invalid = append(invalid, m)
+			continue
+		}
+		if strings.HasPrefix(m, excludePrefix+":") {
+			continue
+		}
+		set[m] = nil
+	}
+
+	if len(invalid) > 0 {
+		sort.Strings(invalid)
+		return nil, fmt.Errorf("%s contains %s-only mixin(s): %s", style.Symbol(imageName), invalidPrefix, strings.Join(invalid, ", "))
+	}
+	return set, nil
+}
+
+func validateMissing(actual, required map[string]interface{}, actualImageName string) error {
+	var missing []string
+	for m := range required {
+		if _, ok := actual[m]; !ok {
+			missing = append(missing, m)
+		}
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("%s missing required mixin(s): %s", style.Symbol(actualImageName), strings.Join(missing, ", "))
+	}
+	return nil
+}

--- a/stack/mixins_test.go
+++ b/stack/mixins_test.go
@@ -1,0 +1,63 @@
+package stack_test
+
+import (
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpack/pack/stack"
+	h "github.com/buildpack/pack/testhelpers"
+)
+
+func TestMixinValidation(t *testing.T) {
+	color.Disable(true)
+	defer func() { color.Disable(false) }()
+	spec.Run(t, "testMixinValidation", testMixinValidation, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testMixinValidation(t *testing.T, when spec.G, it spec.S) {
+	when("#ValidateMixins", func() {
+		it("ignores stage-specific mixins", func() {
+			buildMixins := []string{"mixinA", "build:mixinB"}
+			runMixins := []string{"mixinA", "run:mixinC"}
+
+			h.AssertNil(t, stack.ValidateMixins("some/build", buildMixins, "some/run", runMixins))
+		})
+
+		it("allows extraneous run image mixins", func() {
+			buildMixins := []string{"mixinA"}
+			runMixins := []string{"mixinA", "mixinB"}
+
+			h.AssertNil(t, stack.ValidateMixins("some/build", buildMixins, "some/run", runMixins))
+		})
+
+		it("returns an error with any missing run image mixins", func() {
+			buildMixins := []string{"mixinA", "mixinB"}
+			runMixins := []string{}
+
+			err := stack.ValidateMixins("some/build", buildMixins, "some/run", runMixins)
+
+			h.AssertError(t, err, "'some/run' missing required mixin(s): mixinA, mixinB")
+		})
+
+		it("returns an error with any invalid build image mixins", func() {
+			buildMixins := []string{"run:mixinA", "run:mixinB"}
+			runMixins := []string{}
+
+			err := stack.ValidateMixins("some/build", buildMixins, "some/run", runMixins)
+
+			h.AssertError(t, err, "'some/build' contains run-only mixin(s): run:mixinA, run:mixinB")
+		})
+
+		it("returns an error with any invalid run image mixins", func() {
+			buildMixins := []string{}
+			runMixins := []string{"build:mixinA", "build:mixinB"}
+
+			err := stack.ValidateMixins("some/build", buildMixins, "some/run", runMixins)
+
+			h.AssertError(t, err, "'some/run' contains build-only mixin(s): build:mixinA, build:mixinB")
+		})
+	})
+}

--- a/testdata/buildpack/buildpack.toml
+++ b/testdata/buildpack/buildpack.toml
@@ -6,3 +6,4 @@ version = "1.2.3"
 
 [[stacks]]
 id = "some.stack.id"
+mixins = ["mixinX", "build:mixinY", "run:mixinZ"]

--- a/testdata/buildpack2/buildpack.toml
+++ b/testdata/buildpack2/buildpack.toml
@@ -6,3 +6,4 @@ version = "some-other-buildpack-version"
 
 [[stacks]]
 id = "some.stack.id"
+mixins = ["mixinA", "build:mixinB", "run:mixinC"]

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -111,14 +111,28 @@ func AssertNotContains(t *testing.T, actual, expected string) {
 	}
 }
 
-func AssertSliceContains(t *testing.T, slice []string, value string) {
+func AssertSliceContains(t *testing.T, slice []string, values ...string) {
 	t.Helper()
+	sLookup := map[string]interface{}{}
 	for _, s := range slice {
-		if value == s {
-			return
+		sLookup[s] = nil
+	}
+	remainingVals := map[string]interface{}{}
+	for _, v := range values {
+		remainingVals[v] = nil
+	}
+	for _, s := range slice {
+		if _, ok := sLookup[s]; ok {
+			delete(remainingVals, s)
 		}
 	}
-	t.Fatalf("Expected: '%s' to contain element '%s'", slice, value)
+	if len(remainingVals) > 0 {
+		var rem []string
+		for v := range remainingVals {
+			rem = append(rem, v)
+		}
+		t.Fatalf("Expected: '%s' to contain elements '%s'", slice, rem)
+	}
 }
 
 func AssertMatch(t *testing.T, actual string, expected string) {


### PR DESCRIPTION
- During `create-builder`, check that buildpack mixins are satisfied
- During `build`, check that stack image mixins are in agreement, and that buildpack mixins are satisfied

Signed-off-by: Andrew Meyer <ameyer@pivotal.io>

Resolves #179 