### PR TITLE
Remove lifecycle version warning that is never printed

### DIFF
--- a/build.go
+++ b/build.go
@@ -109,18 +109,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 	}
 	defer c.docker.ImageRemove(context.Background(), ephemeralBuilder.Name(), types.ImageRemoveOptions{Force: true})
 
-	descriptor := ephemeralBuilder.LifecycleDescriptor()
-	if descriptor.Info.Version == nil {
-		c.logger.Warnf("lifecycle version unknown, assuming %s", style.Symbol(builder.AssumedLifecycleVersion))
-	} else {
-		c.logger.Debugf("Executing lifecycle version %s", style.Symbol(descriptor.Info.Version.String()))
-	}
-
-	lcPlatformAPIVersion := api.MustParse(builder.AssumedPlatformAPIVersion)
-	if descriptor.API.PlatformVersion != nil {
-		lcPlatformAPIVersion = descriptor.API.PlatformVersion
-	}
-
+	lcPlatformAPIVersion := ephemeralBuilder.LifecycleDescriptor().API.PlatformVersion
 	if !api.MustParse(build.PlatformAPIVersion).SupportsVersion(lcPlatformAPIVersion) {
 		return errors.Errorf(
 			"pack %s (Platform API version %s) is incompatible with builder %s (Platform API version %s)",


### PR DESCRIPTION
At the point at which the lifecycle version is checked, it has been set to the "assumed" version
in constructBuilder when the ephemeral builder is created [1]. The removed check for nil never
evaluates to true. The same happens with the platform API version.

[1] https://github.com/buildpack/pack/blob/master/internal/builder/builder.go#L112-L125

Signed-off-by: Lukas Berger <bergerl@google.com>