### PR TITLE
Include processes in inspect-image output when available

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -362,6 +362,12 @@ func testAcceptance(t *testing.T, when spec.G, it spec.S, packFixturesDir, packP
 							if _, err := os.Stat(outputTemplate); err != nil {
 								t.Fatal(err.Error())
 							}
+							type process struct {
+								shell       string
+								processType string
+								command     string
+								args        []string
+							}
 							expectedOutput := fillTemplate(t, outputTemplate,
 								map[string]interface{}{
 									"image_name":             repoName,
@@ -370,6 +376,7 @@ func testAcceptance(t *testing.T, when spec.G, it spec.S, packFixturesDir, packP
 									"run_image_local_mirror": localRunImageMirror,
 									"run_image_mirror":       runImageMirror,
 									"show_reference":         !lifecycleDescriptor.Info.Version.LessThan(semver.MustParse("0.5.0")),
+									"show_processes":         !lifecycleDescriptor.Info.Version.LessThan(semver.MustParse("0.6.0")),
 								},
 							)
 							h.AssertEq(t, output, expectedOutput)
@@ -721,6 +728,7 @@ func testAcceptance(t *testing.T, when spec.G, it spec.S, packFixturesDir, packP
 										"base_image_top_layer": h.TopLayerDiffID(t, runImageMirror),
 										"run_image_mirror":     runImageMirror,
 										"show_reference":       !lifecycleDescriptor.Info.Version.LessThan(semver.MustParse("0.5.0")),
+										"show_processes":       !lifecycleDescriptor.Info.Version.LessThan(semver.MustParse("0.6.0")),
 									},
 								)
 								h.AssertEq(t, output, expectedOutput)

--- a/acceptance/testdata/mock_app/run
+++ b/acceptance/testdata/mock_app/run
@@ -2,9 +2,11 @@
 
 set -x
 
+port="${1-8080}"
+
 echo "listening on port 8080"
 
 resp=$(echo "HTTP/1.1 200 OK\n" && cat "$PWD"/*-dep /contents*.txt)
 while true; do
-  nc -l -p 8080 -c "echo \"$resp\""
+  nc -l -p "$port" -c "echo \"$resp\""
 done

--- a/acceptance/testdata/mock_buildpacks/0.2/simple-layers-buildpack/bin/build
+++ b/acceptance/testdata/mock_buildpacks/0.2/simple-layers-buildpack/bin/build
@@ -29,6 +29,17 @@ else
 fi
 
 ## adds a process
-echo 'processes = [{ type = "web", command = "./run"}]' > "$launch_dir/launch.toml"
+cat <<EOF > "$launch_dir/launch.toml"
+[[processes]]
+  type = "web"
+  command = "./run"
+  args = ["8080"]
+
+[[processes]]
+  type = "hello"
+  command = "echo"
+  args = ["hello", "world"]
+  direct = true
+EOF
 
 echo "---> Done"

--- a/acceptance/testdata/pack_current/inspect_image_local_output.txt
+++ b/acceptance/testdata/pack_current/inspect_image_local_output.txt
@@ -21,4 +21,11 @@ Run Images:
 Buildpacks:
   ID                   VERSION
   simple/layers        simple-layers-version
+{{- if .show_processes}}
+
+Processes:
+  TYPE                 SHELL        COMMAND        ARGS
+  web (default)        bash         ./run          8080
+  hello                             echo           hello world
+{{- end }}
 

--- a/acceptance/testdata/pack_current/inspect_image_published_output.txt
+++ b/acceptance/testdata/pack_current/inspect_image_published_output.txt
@@ -17,6 +17,13 @@ Run Images:
 Buildpacks:
   ID                   VERSION
   simple/layers        simple-layers-version
+{{- if .show_processes}}
+
+Processes:
+  TYPE                 SHELL        COMMAND        ARGS
+  web (default)        bash         ./run          8080
+  hello                             echo           hello world
+{{- end }}
 
 
 LOCAL:
@@ -36,4 +43,11 @@ Run Images:
 Buildpacks:
   ID                   VERSION
   simple/layers        simple-layers-version
+{{- if .show_processes}}
+
+Processes:
+  TYPE                 SHELL        COMMAND        ARGS
+  web (default)        bash         ./run          8080
+  hello                             echo           hello world
+{{- end }}
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e
 	github.com/onsi/gomega v1.7.0
 	github.com/pkg/errors v0.8.1
-	github.com/sclevine/spec v1.2.0
+	github.com/sclevine/spec v1.3.0
 	github.com/spf13/cobra v0.0.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/sclevine/spec v1.0.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sclevine/spec v1.2.0 h1:1Jwdf9jSfDl9NVmt8ndHqbTZ7XCCPbh1jI3hkDBHVYA=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
+github.com/sclevine/spec v1.3.0 h1:iTB51CYlnju5oRh0/l67fg1+RlQ2nqmFecwdvN+5TrI=
+github.com/sclevine/spec v1.3.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=


### PR DESCRIPTION
When using lifecycle version 0.6.0 or greater to build an image, the output of `pack inspect-image` will now include a list of processes defined by a buildpack. The output will indicate which process, if any, is the default.

Calls to `pack.Client`'s `InspectImage` command will include an additional `Processes` element of `ProcessDetails` including a `DefaultProcess` if there is one, as well as a slice of `OtherProcesses`.