### PR TITLE
Differentiate between lifecycle implementations in acceptance tests

### DIFF
--- a/acceptance/testconfig/all.json
+++ b/acceptance/testconfig/all.json
@@ -2,6 +2,5 @@
   {"pack": "current", "pack_create_builder": "current", "lifecycle": "current"},
   {"pack": "current", "pack_create_builder": "current", "lifecycle": "previous"},
   {"pack": "current", "pack_create_builder": "previous", "lifecycle": "previous"},
-  {"pack": "previous", "pack_create_builder": "current", "lifecycle": "current"},
   {"pack": "previous", "pack_create_builder": "current", "lifecycle": "previous"}
 ]

--- a/internal/build/phase.go
+++ b/internal/build/phase.go
@@ -94,6 +94,13 @@ func WithDaemonAccess() func(*Phase) (*Phase, error) {
 	}
 }
 
+func WithRoot() func(*Phase) (*Phase, error) {
+	return func(phase *Phase) (*Phase, error) {
+		phase.ctrConf.User = "root"
+		return phase, nil
+	}
+}
+
 func WithBinds(binds ...string) func(*Phase) (*Phase, error) {
 	return func(phase *Phase) (*Phase, error) {
 		phase.hostConf.Binds = append(phase.hostConf.Binds, binds...)

--- a/internal/build/phase_test.go
+++ b/internal/build/phase_test.go
@@ -214,6 +214,19 @@ func testPhase(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 
+			when("#WithRoot", func() {
+				it("sets the containers user to root", func() {
+					phase, err := subject.NewPhase(
+						"phase",
+						build.WithArgs("user"),
+						build.WithRoot(),
+					)
+					h.AssertNil(t, err)
+					assertRunSucceeds(t, phase, &outBuf, &errBuf)
+					h.AssertContains(t, outBuf.String(), "[phase] current user is root")
+				})
+			})
+
 			when("#WithBinds", func() {
 				it.After(func() {
 					docker.VolumeRemove(context.TODO(), "some-volume", true)

--- a/internal/build/phases.go
+++ b/internal/build/phases.go
@@ -81,6 +81,7 @@ func (l *Lifecycle) newAnalyze(repoName, cacheName string, publish, clearCache b
 		return l.NewPhase(
 			"analyzer",
 			WithRegistryAccess(repoName),
+			WithRoot(),
 			WithArgs(args...),
 			WithBinds(fmt.Sprintf("%s:%s", cacheName, cacheDir)),
 		)

--- a/internal/build/testdata/fake-lifecycle/phase.go
+++ b/internal/build/testdata/fake-lifecycle/phase.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/user"
 	"path/filepath"
 	"syscall"
 
@@ -48,6 +49,9 @@ func main() {
 	}
 	if len(os.Args) > 1 && os.Args[1] == "network" {
 		testNetwork()
+	}
+	if len(os.Args) > 1 && os.Args[1] == "user" {
+		testUser()
 	}
 }
 
@@ -189,4 +193,15 @@ func readDir(dir string) {
 			readDir(absPath)
 		}
 	}
+}
+
+func testUser() {
+	fmt.Println("user test")
+	user, err := user.Current()
+	if err != nil {
+		fmt.Printf("failed to determine current user: %s\n", err)
+		return
+	}
+
+	fmt.Printf("current user is %s\n", user.Name)
 }


### PR DESCRIPTION
- Remove temporarily incompatible compatibility configuration
- Remove unused variables
- Add ability to define root user independently of binding daemon

Signed-off-by: Andrew Meyer <ameyer@pivotal.io>
Signed-off-by: Simon Jones <sijones@pivotal.io>